### PR TITLE
No config freezing [fixes Buffer.from(Uint8Array).length]

### DIFF
--- a/packages/algob/src/internal/core/config/config-resolution.ts
+++ b/packages/algob/src/internal/core/config/config-resolution.ts
@@ -40,7 +40,6 @@ export function resolveConfig (
   userConfig: AlgobConfig,
   configExtenders: ConfigExtender[]
 ): ResolvedAlgobConfig {
-  userConfig = deepFreezeUserConfig(userConfig);
 
   const config: Partial<ResolvedAlgobConfig> = mergeUserAndDefaultConfigs(defaultConfig, userConfig);
 
@@ -107,37 +106,4 @@ export function resolveProjectPaths (
     artifacts: resolvePathFrom(root, "artifacts", userPaths.artifacts),
     tests: resolvePathFrom(root, "test", userPaths.tests)
   };
-}
-
-function deepFreezeUserConfig (
-  config: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-  propertyPath: Array<string | number | symbol> = []
-): any { // eslint-disable-line @typescript-eslint/no-explicit-any
-  if (typeof config !== "object" || config === null) {
-    return config;
-  }
-
-  return new Proxy(config, {
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    get (target: any, property: string | number | symbol, receiver: any): any {
-      return deepFreezeUserConfig(Reflect.get(target, property, receiver), [
-        ...propertyPath,
-        property
-      ]);
-    },
-
-    set (
-      target: any,
-      property: string | number | symbol,
-      value: any,
-      receiver: any
-    ): boolean {
-      throw new BuilderError(ERRORS.GENERAL.USER_CONFIG_MODIFIED, {
-        path: [...propertyPath, property]
-          .map((pathPart) => pathPart.toString())
-          .join(".")
-      });
-    }
-    /* eslint-enable @typescript-eslint/no-explicit-any */
-  });
 }

--- a/packages/algob/test/internal/core/config/config-extensions.ts
+++ b/packages/algob/test/internal/core/config/config-extensions.ts
@@ -39,16 +39,5 @@ describe("Config extensions", function () {
     afterEach(function () {
       resetBuilderContext();
     });
-
-    it("Should throw the right error when trying to modify the user config", function () {
-      expectBuilderError(
-        () => loadConfigAndTasks(),
-        ERRORS.GENERAL.USER_CONFIG_MODIFIED
-      );
-    });
-
-    it("Should have the right property path", function () {
-      assert.throws(() => loadConfigAndTasks(), "userConfig.networks.asd");
-    });
   });
 });


### PR DESCRIPTION
`Buffer.from(new Uint8Array([1])).length` will crash if this won't be modified. Therefore it's being removed.
Observed as `nacl` couldn't sign using a "frozen" secret key.

Error:
```
Method get TypedArray.prototype.length called on incompatible receiver [object Object]
```