### PR TITLE
fix concat op in runtime

### DIFF
--- a/packages/runtime/src/interpreter/opcode-list.ts
+++ b/packages/runtime/src/interpreter/opcode-list.ts
@@ -1105,8 +1105,8 @@ export class Concat extends Op {
 
   execute (stack: TEALStack): void {
     this.assertMinStackLen(stack, 2, this.line);
-    const valueB = this.assertBytes(stack.pop(), this.line);
     const valueA = this.assertBytes(stack.pop(), this.line);
+    const valueB = this.assertBytes(stack.pop(), this.line);
 
     if (valueA.length + valueB.length > MAX_CONCAT_SIZE) {
       throw new RuntimeError(RUNTIME_ERRORS.TEAL.CONCAT_ERROR, { line: this.line });

--- a/packages/runtime/test/src/interpreter/opcode-list.ts
+++ b/packages/runtime/test/src/interpreter/opcode-list.ts
@@ -1286,11 +1286,19 @@ describe("Teal Opcodes", function () {
     it("should concat two byte strings", () => {
       stack.push(new Uint8Array([3, 2, 1]));
       stack.push(new Uint8Array([1, 2, 3]));
-      const op = new Concat([], 1);
+      let op = new Concat([], 1);
       op.execute(stack);
 
-      const top = stack.pop();
-      assert.deepEqual(top, new Uint8Array([1, 2, 3, 3, 2, 1]));
+      let top = stack.pop();
+      assert.deepEqual(top, new Uint8Array([3, 2, 1, 1, 2, 3]));
+
+      stack.push(stringToBytes("Hello"));
+      stack.push(stringToBytes("Friend"));
+      op = new Concat([], 1);
+      op.execute(stack);
+
+      top = stack.pop();
+      assert.deepEqual(top, stringToBytes("HelloFriend"));
     });
 
     it("should throw error as byte strings too long", () => {


### PR DESCRIPTION
The order of `Concat(x, y)` in *runtime* was `yx`, but it should be `xy`