### PR TITLE
Should not be able to close asset using clawback 

### DIFF
--- a/packages/runtime/src/errors/errors-list.ts
+++ b/packages/runtime/src/errors/errors-list.ts
@@ -385,6 +385,12 @@ const runtimeAsaErrors = {
     message: "All of the created assets should be in creator's account",
     title: "Asset Total Error",
     description: "Asset Total Error"
+  },
+  CANNOT_CLOSE_ASSET_BY_CLAWBACK: {
+    number: 1509,
+    message: `Assetholding of account cannot be closed by clawback`,
+    title: "Close asset by clawback error",
+    description: "Cannot close asset by clawback"
   }
 };
 

--- a/packages/runtime/src/errors/errors-list.ts
+++ b/packages/runtime/src/errors/errors-list.ts
@@ -390,7 +390,7 @@ const runtimeAsaErrors = {
     number: 1509,
     message: `Assetholding of account cannot be closed by clawback`,
     title: "Close asset by clawback error",
-    description: "Cannot close asset by clawback"
+    description: "Clawback cannot close asset holding from an algorand account. Only the actual owner of that account can. Read more about asset parameters at https://developer.algorand.org/docs/features/asa/#asset-parameters"
   }
 };
 


### PR DESCRIPTION
- Should not be able to close asset using clawback, added test
- Also checked that asset transfer is only account if both asset sender and receiver are not `frozen`, but if amount is 0 then txn is accepted. Added test

closes #311 