### PR TITLE
(Updated) Permissioned Token tests

### DIFF
--- a/examples/permissioned-token/assets/controller.py
+++ b/examples/permissioned-token/assets/controller.py
@@ -160,7 +160,7 @@ def approval_program(TOKEN_ID):
                     # If the receiver is the reserve address - old, or the new one being updated in the assset config tx (Gtxn[3]),
                     # then it can bypass permission checks
                     Gtxn[1].asset_receiver() == assetReserve.value(),
-                    Gtxn[1].asset_receiver() == Gtxn[3].config_asset_reserve()
+                    If(Global.group_size() > Int(3), Gtxn[1].asset_receiver() == Gtxn[3].config_asset_reserve(), Int(0))
                 ),
                 Int(1),
                 # else verify that permissions ssc is called

--- a/examples/permissioned-token/package.json
+++ b/examples/permissioned-token/package.json
@@ -10,7 +10,7 @@
     "algob": "algob",
     "lint": "eslint --ext .js,.ts scripts",
     "lint:fix": "eslint --fix --ext .js,.ts scripts",
-    "test": "echo ok",
+    "test": "mocha",
     "build:docs": "echo ok",
     "build": "echo ok"
   },

--- a/examples/permissioned-token/scripts/admin/force-transfer.js
+++ b/examples/permissioned-token/scripts/admin/force-transfer.js
@@ -123,7 +123,6 @@ async function run (runtimeEnv, deployer) {
 
   // opt-in accounts to permissions smart contract
   // comment this code if already opted-in
-  await optInAccountToSSC(deployer, asaManager, permissionsSSCInfo.appID, {}, {});
   await optInAccountToSSC(deployer, elon, permissionsSSCInfo.appID, {}, {});
   await optInAccountToSSC(deployer, bob, permissionsSSCInfo.appID, {}, {});
   await optInAccountToSSC(deployer, john, permissionsSSCInfo.appID, {}, {});
@@ -135,7 +134,6 @@ async function run (runtimeEnv, deployer) {
    * NOTE: whitelist() transaction will be executed by the permissionsManager,
    * current_user (a non reserve account) will not control permissionsManager account.
    */
-  await whitelist(deployer, permissionsManager, asaManager.addr);
   await whitelist(deployer, permissionsManager, bob.addr);
   await whitelist(deployer, permissionsManager, john.addr);
 

--- a/examples/permissioned-token/test/common.js
+++ b/examples/permissioned-token/test/common.js
@@ -1,0 +1,379 @@
+const {
+  getProgram
+} = require('@algo-builder/algob');
+const { Runtime, AccountStore, types } = require('@algo-builder/runtime');
+
+const minBalance = 20e6; // 20 ALGOs
+
+const CLAWBACK = 'clawback.py';
+const CONTROLLER = 'controller.py';
+const PERMISSIONS = 'permissions.py';
+const CLEAR_STATE = 'clear_state_program.py';
+
+const ALICE_ADDRESS = 'EDXG4GGBEHFLNX6A7FGT3F6Z3TQGIU6WVVJNOXGYLVNTLWDOCEJJ35LWJY';
+
+let master = new AccountStore(10000e6);
+let alice, bob, elon;
+let runtime;
+let assetIndex;
+let lsig;
+let controllerAppID, permissionsAppId;
+
+let CLAWBACK_PROGRAM;
+let CONTROLLER_PROGRAM;
+let PERMISSIONS_PROGRAM;
+const CLEAR_STATE_PROGRAM = getProgram(CLEAR_STATE);
+
+const TRANSFER_ARG = 'str:transfer';
+
+// Sync Accounts
+function syncAccounts (runtime) {
+  master = runtime.getAccount(master.address);
+  alice = runtime.getAccount(alice.address);
+  bob = runtime.getAccount(bob.address);
+  elon = runtime.getAccount(elon.address);
+}
+
+/**
+ * - Setup token (ASA gold)
+ * - Setup Controller asc
+ * - Setup asset clawback + update asset clawback to escrow contract
+ * - Setup permissions smart contract
+ * NOTE: During setup - ASA.reserve, ASA.manager & current_permissions_manager is set as alice.address
+ */
+function setupEnv () {
+  // Create Accounts and Env
+  alice = new AccountStore(minBalance, { addr: ALICE_ADDRESS, sk: new Uint8Array(0) });
+  bob = new AccountStore(minBalance);
+  elon = new AccountStore(minBalance);
+  runtime = new Runtime([master, alice, bob, elon]);
+
+  // Deploy ASA
+  assetIndex = runtime.addAsset('gold', { creator: { ...alice.account, name: 'alice' } });
+  const asaDef = runtime.getAssetDef(assetIndex);
+
+  // Deploy Controller SSC
+  let sscFlags = {
+    sender: alice.account,
+    localInts: 0,
+    localBytes: 0,
+    globalInts: 2,
+    globalBytes: 0,
+    foreignAssets: [assetIndex]
+  };
+  CONTROLLER_PROGRAM = getProgram(CONTROLLER, { TOKEN_ID: assetIndex });
+  controllerAppID = runtime.addApp(
+    sscFlags, {}, CONTROLLER_PROGRAM, CLEAR_STATE_PROGRAM
+  );
+
+  // Deploy Clawback Lsig and Modify Asset
+  CLAWBACK_PROGRAM = getProgram(CLAWBACK, {
+    TOKEN_ID: assetIndex,
+    CONTROLLER_APP_ID: controllerAppID
+  });
+  lsig = runtime.getLogicSig(CLAWBACK_PROGRAM, []);
+  fund(runtime, master, lsig.address());
+  runtime.executeTx({
+    type: types.TransactionType.ModifyAsset,
+    sign: types.SignType.SecretKey,
+    fromAccount: alice.account,
+    assetID: assetIndex,
+    fields: {
+      manager: asaDef.manager,
+      reserve: asaDef.reserve,
+      freeze: asaDef.freeze,
+      clawback: lsig.address()
+    },
+    payFlags: { totalFee: 1000 }
+  });
+  optInToASA(runtime, lsig.address(), assetIndex);
+
+  syncAccounts(runtime);
+
+  // Deploy Permissions SSC
+  PERMISSIONS_PROGRAM = getProgram(PERMISSIONS, { PERM_MANAGER: alice.address });
+  sscFlags = {
+    sender: alice.account,
+    localInts: 1,
+    localBytes: 0,
+    globalInts: 2,
+    globalBytes: 1,
+    appArgs: [`int:${controllerAppID}`]
+  };
+  permissionsAppId = runtime.addApp(
+    sscFlags, {}, PERMISSIONS_PROGRAM, CLEAR_STATE_PROGRAM
+  );
+
+  // Add permissions SSC config to Controller SSC
+  const appArgs = [
+    'str:set_permission',
+    `int:${permissionsAppId}`
+  ];
+  runtime.executeTx({
+    type: types.TransactionType.CallNoOpSSC,
+    sign: types.SignType.SecretKey,
+    fromAccount: alice.account,
+    appId: controllerAppID,
+    payFlags: { totalFee: 1000 },
+    appArgs: appArgs,
+    foreignAssets: [assetIndex]
+  });
+
+  // Refresh Accounts
+  syncAccounts(runtime);
+
+  return [
+    runtime,
+    master,
+    alice,
+    bob,
+    elon,
+    assetIndex,
+    controllerAppID,
+    lsig,
+    permissionsAppId
+  ];
+};
+
+// Opt-In account to ASA
+function optInToASA (runtime, address, assetIndex) {
+  runtime.optIntoASA(assetIndex, address, {});
+}
+
+// Opt-In address to Permissions SSC
+function optInToPermissionsSSC (runtime, address, permissionsAppId) {
+  runtime.optInToApp(address, permissionsAppId, {}, {});
+}
+
+/**
+ * Issue some tokens to the passed account
+ * @param runtime RuntimeEnv Instance
+ * @param asaReserve ASA Reserve Account
+ * @param receiver Receiver Account
+ * @param amount Amount
+ * @param controllerAppID Controller App ID
+ * @param assetIndex ASA ID (Token ID)
+ * @param lsig (Clawback LSig)
+ */
+function issue (runtime, asaReserve, receiver, amount, controllerAppID, assetIndex, lsig) {
+  const txns = [
+    {
+      type: types.TransactionType.CallNoOpSSC,
+      sign: types.SignType.SecretKey,
+      fromAccount: asaReserve,
+      appId: controllerAppID,
+      payFlags: { totalFee: 1000 },
+      appArgs: ['str:issue'],
+      foreignAssets: [assetIndex]
+    },
+    {
+      type: types.TransactionType.RevokeAsset,
+      sign: types.SignType.LogicSignature,
+      fromAccountAddr: lsig.address(),
+      recipient: receiver.address,
+      assetID: assetIndex,
+      revocationTarget: asaReserve.addr,
+      amount: amount,
+      lsig: lsig,
+      payFlags: { totalFee: 1000 }
+    }
+  ];
+  runtime.executeTx(txns);
+}
+
+/**
+ * Kill the token
+ * @param runtime RuntimeEnv Instance
+ * @param asaManager ASA Manager Account
+ * @param controllerAppID Controller App ID
+ */
+function killToken (runtime, asaManager, controllerAppID) {
+  runtime.executeTx({
+    type: types.TransactionType.CallNoOpSSC,
+    sign: types.SignType.SecretKey,
+    fromAccount: asaManager,
+    appId: controllerAppID,
+    payFlags: { totalFee: 1000 },
+    appArgs: ['str:kill'],
+    foreignAssets: [assetIndex]
+  });
+}
+
+/**
+ * Whitelists the passed address for allowing token transfer
+ * @param runtime RuntimeEnv Instance
+ * @param permManager Permissions Manager Account
+ * @param addrToWhitelist Address to be whitelisted
+ * @param permissionsAppId Permissions App ID
+ */
+function whitelist (runtime, permManager, addrToWhitelist, permissionsAppId) {
+  optInToPermissionsSSC(runtime, addrToWhitelist, permissionsAppId);
+  runtime.executeTx({
+    type: types.TransactionType.CallNoOpSSC,
+    sign: types.SignType.SecretKey,
+    fromAccount: permManager,
+    appId: permissionsAppId,
+    payFlags: { totalFee: 1000 },
+    appArgs: ['str:add_whitelist'],
+    accounts: [addrToWhitelist]
+  });
+}
+
+/**
+ * Fund the address with min ALGOs(20)
+ * @param runtime RuntimeEnv Instance
+ * @param master Master Account
+ * @param address Receiver Account Address
+ */
+function fund (runtime, master, address) {
+  runtime.executeTx({
+    type: types.TransactionType.TransferAlgo,
+    sign: types.SignType.SecretKey,
+    fromAccount: master.account,
+    toAccountAddr: address,
+    amountMicroAlgos: minBalance,
+    payFlags: {}
+  });
+}
+
+/**
+ * Transfer ASA
+ * @param runtime RuntimeEnv Instance
+ * @param from Sender Account
+ * @param to Receiver Account
+ * @param amount Amount
+ * @param assetIndex ASA ID
+ * @param controllerAppID Controller App ID
+ * @param permissionsAppId Permissions App ID
+ * @param lsig Clawback LSig
+ */
+function transfer (runtime, from, to, amount, assetIndex, controllerAppID, permissionsAppId, lsig) {
+  const txGroup = [
+    {
+      type: types.TransactionType.CallNoOpSSC,
+      sign: types.SignType.SecretKey,
+      fromAccount: from.account,
+      appId: controllerAppID,
+      payFlags: { totalFee: 1000 },
+      appArgs: [TRANSFER_ARG]
+    },
+    {
+      type: types.TransactionType.RevokeAsset,
+      sign: types.SignType.LogicSignature,
+      fromAccountAddr: lsig.address(),
+      recipient: to.address,
+      assetID: assetIndex,
+      revocationTarget: from.address,
+      amount: amount,
+      lsig: lsig,
+      payFlags: { totalFee: 1000 }
+    },
+    {
+      type: types.TransactionType.TransferAlgo,
+      sign: types.SignType.SecretKey,
+      fromAccount: from.account,
+      toAccountAddr: lsig.address(),
+      amountMicroAlgos: 1000,
+      payFlags: { totalFee: 1000 }
+    },
+    {
+      type: types.TransactionType.CallNoOpSSC,
+      sign: types.SignType.SecretKey,
+      fromAccount: from.account,
+      appId: permissionsAppId,
+      payFlags: { totalFee: 1000 },
+      appArgs: [TRANSFER_ARG],
+      accounts: [from.address, to.address]
+    }
+  ];
+  runtime.executeTx(txGroup);
+}
+
+/**
+ * Performs Opt-Out operation
+ * @param runtime RuntimeEnv
+ * @param asaCreatorAddr ASA Creator Address
+ * @param account Account to be Opted-Out
+ * @param assetIndex ASA ID
+ */
+function optOut (runtime, asaCreatorAddr, account, assetIndex) {
+  const optOutParams = {
+    type: types.TransactionType.TransferAsset,
+    sign: types.SignType.SecretKey,
+    fromAccount: account,
+    toAccountAddr: account.addr,
+    assetID: assetIndex,
+    amount: 0,
+    payFlags: { totalFee: 1000, closeRemainderTo: asaCreatorAddr }
+  };
+  runtime.executeTx(optOutParams);
+}
+
+/**
+ * Force Transfer Tokens
+ * @param runtime RuntimeEnv Instance
+ * @param from Sender Account
+ * @param to Receiver Account
+ * @param amount Amount
+ * @param assetIndex ASA ID
+ * @param controllerAppID Controller App ID
+ * @param permissionsAppId Permissions App ID
+ * @param lsig Clawback LSig
+ * @param asaManager ASA Manager Account
+ */
+function forceTransfer (
+  runtime, from, to, amount, assetIndex, controllerAppID, permissionsAppId, lsig, asaManager) {
+  const txGroup = [
+    {
+      type: types.TransactionType.CallNoOpSSC,
+      sign: types.SignType.SecretKey,
+      fromAccount: asaManager,
+      appId: controllerAppID,
+      payFlags: { totalFee: 1000 },
+      appArgs: ['str:force_transfer'],
+      foreignAssets: [assetIndex]
+    },
+    {
+      type: types.TransactionType.RevokeAsset,
+      sign: types.SignType.LogicSignature,
+      fromAccountAddr: lsig.address(),
+      recipient: to.address,
+      assetID: assetIndex,
+      revocationTarget: from.address,
+      amount: amount,
+      lsig: lsig,
+      payFlags: { totalFee: 1000 }
+    },
+    {
+      type: types.TransactionType.TransferAlgo,
+      sign: types.SignType.SecretKey,
+      fromAccount: asaManager,
+      toAccountAddr: lsig.address(),
+      amountMicroAlgos: 1000,
+      payFlags: { totalFee: 1000 }
+    },
+    {
+      type: types.TransactionType.CallNoOpSSC,
+      sign: types.SignType.SecretKey,
+      fromAccount: asaManager,
+      appId: permissionsAppId,
+      payFlags: { totalFee: 1000 },
+      appArgs: [TRANSFER_ARG],
+      accounts: [from.address, to.address]
+    }
+  ];
+  runtime.executeTx(txGroup);
+}
+
+module.exports = {
+  optInToASA: optInToASA,
+  optInToPermissionsSSC: optInToPermissionsSSC,
+  issue: issue,
+  killToken: killToken,
+  whitelist: whitelist,
+  fund: fund,
+  transfer: transfer,
+  optOut: optOut,
+  forceTransfer: forceTransfer,
+  setupEnv: setupEnv
+};

--- a/examples/permissioned-token/test/failing-paths.js
+++ b/examples/permissioned-token/test/failing-paths.js
@@ -1,0 +1,627 @@
+const { types } = require('@algo-builder/runtime');
+const { assert } = require('chai');
+const { encodeAddress } = require('algosdk');
+const {
+  optInToASA,
+  optInToPermissionsSSC,
+  issue,
+  whitelist,
+  killToken,
+  transfer,
+  optOut,
+  forceTransfer,
+  setupEnv
+} = require('./common');
+
+const STR_TRANSFER = 'str:transfer';
+const RUNTIME_ERR1009 = 'RUNTIME_ERR1009: TEAL runtime encountered err opcode';
+const INDEX_OUT_OF_BOUND_ERR = 'RUNTIME_ERR1008: Index out of bound';
+const REJECTED_BY_LOGIC = 'RUNTIME_ERR1007: Teal code rejected by logic';
+
+describe('Permissioned Token Tests - Failing Paths', function () {
+  let runtime, master, alice, bob, elon;
+  let lsig, assetIndex, controllerAppID, permissionsAppId;
+  let asaDef, asaReserve, asaManager;
+
+  function syncAccounts () {
+    master = runtime.getAccount(master.address);
+    alice = runtime.getAccount(alice.address);
+    bob = runtime.getAccount(bob.address);
+    elon = runtime.getAccount(elon.address);
+  }
+
+  // Create Accounts and Env
+  function _setupEnv () {
+    [
+      runtime,
+      master,
+      alice,
+      bob,
+      elon,
+      assetIndex,
+      controllerAppID,
+      lsig,
+      permissionsAppId
+    ] = setupEnv();
+  }
+
+  this.beforeEach(async function () {
+    _setupEnv();
+    asaDef = runtime.getAssetDef(assetIndex);
+    asaReserve = runtime.getAccount(asaDef.reserve);
+    asaManager = runtime.getAccount(asaDef.manager);
+  });
+
+  describe('Token Issuance', function () {
+    it('should not issue token if receiver is not opted in', () => {
+      assert.throws(() =>
+        issue(runtime, asaReserve.account, elon, 20, controllerAppID, assetIndex, lsig),
+        `RUNTIME_ERR1404: Account ${elon.address} doesn't hold asset index ${assetIndex}`);
+    });
+
+    it('should not issue if token is killed', () => {
+      // Opt-in to ASA by receiver
+      optInToASA(runtime, elon.address, assetIndex);
+      syncAccounts();
+
+      killToken(runtime, asaManager.account, controllerAppID);
+      assert.throws(() =>
+        issue(runtime, asaReserve.account, elon, 20, controllerAppID, assetIndex, lsig),
+      RUNTIME_ERR1009);
+    });
+
+    it('should reject issuance tx if sender is not token reserve', () => {
+      // Opt-in to ASA by receiver
+      optInToASA(runtime, elon.address, assetIndex);
+      syncAccounts();
+
+      assert.throws(() =>
+        issue(runtime, bob.account, elon, 20, controllerAppID, assetIndex, lsig),
+      RUNTIME_ERR1009);
+    });
+
+    it('should reject issuance tx if trying to send asset using secret key instead of clawback', () => {
+      // Opt-in to ASA by receiver
+      optInToASA(runtime, elon.address, assetIndex);
+      syncAccounts();
+
+      const txParams = {
+        type: types.TransactionType.TransferAsset,
+        sign: types.SignType.SecretKey,
+        fromAccount: asaReserve.account,
+        toAccountAddr: elon.address,
+        amount: 20n,
+        assetID: assetIndex,
+        payFlags: {}
+      };
+
+      // should fail as we can only use clawback (since asset is default-frozen)
+      assert.throws(() =>
+        runtime.executeTx(txParams),
+        `RUNTIME_ERR1505: Asset index ${assetIndex} frozen for account ${elon.address}`);
+    });
+  });
+
+  describe('Kill Token', function () {
+    it('should reject tx to kill token if sender is not token manager', () => {
+      // verify bob is not token manager
+      assert.notEqual(asaManager.address, bob.address);
+      // bob trying to kill token
+      assert.throws(() =>
+        killToken(runtime, bob.account, controllerAppID),
+      RUNTIME_ERR1009);
+    });
+  });
+
+  describe('WhiteListing', function () {
+    let permManagerAddr, permManager, whitelistParams;
+    this.beforeEach(() => {
+      permManagerAddr = encodeAddress(runtime.getGlobalState(permissionsAppId, 'manager'));
+      permManager = runtime.getAccount(permManagerAddr);
+
+      whitelistParams = {
+        type: types.TransactionType.CallNoOpSSC,
+        sign: types.SignType.SecretKey,
+        fromAccount: permManager.account,
+        appId: permissionsAppId,
+        payFlags: { totalFee: 1000 },
+        appArgs: ['str:add_whitelist'],
+        accounts: [elon.address]
+      };
+    });
+
+    it('should reject whitelist if account is not opted in to permissions', () => {
+      // verify account not opted in
+      assert.isUndefined(elon.getAppFromLocal(permissionsAppId));
+
+      // Fails because elon is not opted in
+      assert.throws(() =>
+        runtime.executeTx({ ...whitelistParams }),
+        `RUNTIME_ERR1306: Application Index ${permissionsAppId} not found or is invalid`);
+    });
+
+    it('should not whitelist account if sender is not current permissions manager', () => {
+      // opt-in to permissions by elon
+      optInToPermissionsSSC(runtime, elon.address, permissionsAppId);
+      syncAccounts();
+      assert.isDefined(elon.getAppFromLocal(permissionsAppId));
+
+      // Fails because Bob is not the manager
+      assert.notEqual(permManager.address, bob.address); // verify bob is not permissions manager
+      assert.throws(() => runtime.executeTx({
+        ...whitelistParams,
+        fromAccount: bob.account // Bob is not the asset manager
+      }), RUNTIME_ERR1009);
+    });
+  });
+
+  describe('Opt Out', function () {
+    it('should reject tx if user not opted-in', () => {
+      const asaCreator = runtime.getAccount(asaDef.creator);
+      assert.throws(() =>
+        optOut(runtime, asaCreator.address, elon.account, assetIndex),
+        `RUNTIME_ERR1404: Account ${elon.address} doesn't hold asset index ${assetIndex}`);
+    });
+  });
+
+  describe('Change Permissions Manager', function () {
+    it('should fail if sender is not current permissions manager', () => {
+      const permManagerAddr = encodeAddress(runtime.getGlobalState(permissionsAppId, 'manager'));
+      const permManager = runtime.getAccount(permManagerAddr);
+      assert.notEqual(permManager.address, bob.address); // verify bob is not current permissions manager
+
+      const txParams = {
+        type: types.TransactionType.CallNoOpSSC,
+        sign: types.SignType.SecretKey,
+        fromAccount: bob.account,
+        appId: permissionsAppId,
+        payFlags: { totalFee: 1000 },
+        appArgs: ['str:change_permissions_manager'],
+        accounts: [elon.address]
+      };
+      assert.throws(() =>
+        runtime.executeTx(txParams), // fails as fromAccount is not the current permissions manager
+      RUNTIME_ERR1009);
+    });
+  });
+
+  describe('Force Transfer(Clawback)', function () {
+    let permManagerAddr, permManager, forceTransferGroup;
+    this.beforeEach(() => {
+      permManagerAddr = encodeAddress(runtime.getGlobalState(permissionsAppId, 'manager'));
+      permManager = runtime.getAccount(permManagerAddr);
+
+      // Opt-In to ASA by bob and elon (accA, accB)
+      optInToASA(runtime, bob.address, assetIndex);
+      optInToASA(runtime, elon.address, assetIndex);
+      syncAccounts();
+
+      // transaction group for forced token transfer between two non-reserve accounts
+      // note that sender is asa.manager
+      forceTransferGroup = [
+        {
+          type: types.TransactionType.CallNoOpSSC,
+          sign: types.SignType.SecretKey,
+          fromAccount: asaManager.account,
+          appId: controllerAppID,
+          payFlags: { totalFee: 1000 },
+          appArgs: ['str:force_transfer'],
+          foreignAssets: [assetIndex]
+        },
+        {
+          type: types.TransactionType.RevokeAsset,
+          sign: types.SignType.LogicSignature,
+          fromAccountAddr: lsig.address(),
+          recipient: elon.address,
+          assetID: assetIndex,
+          revocationTarget: bob.address,
+          amount: 20n,
+          lsig: lsig,
+          payFlags: { totalFee: 1000 }
+        },
+        {
+          type: types.TransactionType.TransferAlgo,
+          sign: types.SignType.SecretKey,
+          fromAccount: asaManager.account,
+          toAccountAddr: lsig.address(),
+          amountMicroAlgos: 1000,
+          payFlags: { totalFee: 1000 }
+        },
+        {
+          type: types.TransactionType.CallNoOpSSC,
+          sign: types.SignType.SecretKey,
+          fromAccount: asaManager.account,
+          appId: permissionsAppId,
+          payFlags: { totalFee: 1000 },
+          appArgs: [STR_TRANSFER],
+          accounts: [bob.address, elon.address]
+        }
+      ];
+    });
+
+    it('Should fail on force transfer if transaction group is not valid', () => {
+      const forceTxGroup = [...forceTransferGroup];
+
+      // fails as permissions is not called
+      assert.throws(() =>
+        runtime.executeTx([forceTxGroup[0], forceTxGroup[1], forceTxGroup[2]]),
+      INDEX_OUT_OF_BOUND_ERR
+      );
+
+      // fails if only trying to use clawback transaction to transfer asset
+      assert.throws(() =>
+        runtime.executeTx(forceTxGroup[1]),
+      INDEX_OUT_OF_BOUND_ERR
+      );
+
+      // fails as paying fees of clawback-escrow is skipped
+      assert.throws(() =>
+        runtime.executeTx([forceTxGroup[0], forceTxGroup[1], forceTxGroup[3]]),
+      INDEX_OUT_OF_BOUND_ERR
+      );
+
+      // fails as controller is not called
+      assert.throws(() =>
+        runtime.executeTx([forceTxGroup[1], forceTxGroup[2], forceTxGroup[3]]),
+      REJECTED_BY_LOGIC
+      );
+    });
+
+    it('should reject transfer if transaction group is valid but controller.sender is not equal to asset.sender', () => {
+      const forceTxGroup = [...forceTransferGroup];
+      forceTxGroup[0].fromAccount = elon.account;
+
+      assert.throws(() =>
+        runtime.executeTx(forceTxGroup),
+      RUNTIME_ERR1009
+      );
+    });
+
+    it('Should reject transfer is sender is not token manager', () => {
+      // Opt-In to permissions SSC & Whitelist
+      whitelist(runtime, permManager.account, elon.address, permissionsAppId);
+      whitelist(runtime, permManager.account, bob.address, permissionsAppId);
+      syncAccounts();
+
+      // Issue some tokens to sender
+      issue(runtime, asaReserve.account, bob, 150, controllerAppID, assetIndex, lsig);
+      syncAccounts();
+
+      // Fails as only asset manager(alice) can perform force transfer
+      assert.notEqual(asaManager.address, bob.address);
+      assert.throws(() =>
+        forceTransfer(runtime, bob, elon, 20, assetIndex,
+          controllerAppID, permissionsAppId, lsig, bob.account),
+      RUNTIME_ERR1009
+      );
+    });
+
+    it('Should reject force transfer if accounts are not whitelisted', () => {
+      // Issue some tokens to sender
+      issue(runtime, asaReserve.account, bob, 150, controllerAppID, assetIndex, lsig);
+      syncAccounts();
+
+      // Fails as both sender, receiver are not whitelisted
+      assert.throws(() =>
+        forceTransfer(runtime, bob, elon, 20, assetIndex, controllerAppID,
+          permissionsAppId, lsig, asaManager.account),
+      RUNTIME_ERR1009
+      );
+
+      // still fails as sender is whitelisted but receiver is not
+      whitelist(runtime, permManager.account, bob.address, permissionsAppId);
+      syncAccounts();
+      assert.throws(() =>
+        forceTransfer(runtime, bob, elon, 20, assetIndex, controllerAppID,
+          permissionsAppId, lsig, asaManager.account),
+      RUNTIME_ERR1009
+      );
+
+      // passes now as both sender, receiver are whitelisted
+      whitelist(runtime, permManager.account, elon.address, permissionsAppId);
+      syncAccounts();
+      forceTransfer(runtime, bob, elon, 20, assetIndex, controllerAppID,
+        permissionsAppId, lsig, asaManager.account);
+    });
+
+    it('Should reject force transfer if accounts are whitelisted but receiver balance becomes > 100', () => {
+      // Opt-In to permissions SSC & Whitelist
+      whitelist(runtime, permManager.account, elon.address, permissionsAppId);
+      whitelist(runtime, permManager.account, bob.address, permissionsAppId);
+      syncAccounts();
+
+      // Issue some tokens to sender
+      issue(runtime, asaReserve.account, bob, 150, controllerAppID, assetIndex, lsig);
+      syncAccounts();
+
+      // Fails as receiver balance becomes > 100 now
+      assert.throws(() =>
+        forceTransfer(runtime, bob, elon, 110, assetIndex, controllerAppID,
+          permissionsAppId, lsig, asaManager.account),
+      RUNTIME_ERR1009
+      );
+    });
+
+    it('Should reject force transfer if token is killed', () => {
+      // Opt-In to permissions SSC & Whitelist
+      whitelist(runtime, permManager.account, elon.address, permissionsAppId);
+      whitelist(runtime, permManager.account, bob.address, permissionsAppId);
+      syncAccounts();
+
+      // Issue some tokens to sender and kill token
+      issue(runtime, asaReserve.account, bob, 150, controllerAppID, assetIndex, lsig);
+      killToken(runtime, asaManager.account, controllerAppID);
+      syncAccounts();
+
+      // fails as accounts are whitelisted, amount is good but token is killed
+      assert.throws(() =>
+        forceTransfer(runtime, bob, elon, 20, assetIndex, controllerAppID,
+          permissionsAppId, lsig, asaManager.account),
+      RUNTIME_ERR1009
+      );
+    });
+  });
+
+  describe('Token Transfer', function () {
+    let permManagerAddr, permManager, tokenTransferGroup;
+    this.beforeEach(() => {
+      permManagerAddr = encodeAddress(runtime.getGlobalState(permissionsAppId, 'manager'));
+      permManager = runtime.getAccount(permManagerAddr);
+
+      // Opt-In to ASA by bob and elon (accA, accB)
+      optInToASA(runtime, bob.address, assetIndex);
+      optInToASA(runtime, elon.address, assetIndex);
+      syncAccounts();
+
+      // transaction group for token transfer between two non-reserve accounts
+      tokenTransferGroup = [
+        {
+          type: types.TransactionType.CallNoOpSSC,
+          sign: types.SignType.SecretKey,
+          fromAccount: bob.account,
+          appId: controllerAppID,
+          payFlags: { totalFee: 1000 },
+          appArgs: [STR_TRANSFER],
+          foreignAssets: [assetIndex]
+        },
+        {
+          type: types.TransactionType.RevokeAsset,
+          sign: types.SignType.LogicSignature,
+          fromAccountAddr: lsig.address(),
+          recipient: elon.address,
+          assetID: assetIndex,
+          revocationTarget: bob.address,
+          amount: 20n,
+          lsig: lsig,
+          payFlags: { totalFee: 1000 }
+        },
+        {
+          type: types.TransactionType.TransferAlgo,
+          sign: types.SignType.SecretKey,
+          fromAccount: asaManager.account,
+          toAccountAddr: lsig.address(),
+          amountMicroAlgos: 1000,
+          payFlags: { totalFee: 1000 }
+        },
+        {
+          type: types.TransactionType.CallNoOpSSC,
+          sign: types.SignType.SecretKey,
+          fromAccount: bob.account,
+          appId: permissionsAppId,
+          payFlags: { totalFee: 1000 },
+          appArgs: [STR_TRANSFER],
+          accounts: [bob.address, elon.address]
+        }
+      ];
+    });
+
+    it('Should fail if transaction group is not valid', () => {
+      const txGroup = [...tokenTransferGroup];
+
+      // fails as permissions is not called
+      assert.throws(() =>
+        runtime.executeTx([txGroup[0], txGroup[1], txGroup[2]]),
+      INDEX_OUT_OF_BOUND_ERR
+      );
+
+      // fails if only trying to use clawback transaction to transfer asset
+      assert.throws(() =>
+        runtime.executeTx(txGroup[1]),
+      INDEX_OUT_OF_BOUND_ERR
+      );
+
+      // fails as paying fees of clawback-escrow is skipped
+      assert.throws(() =>
+        runtime.executeTx([txGroup[0], txGroup[1], txGroup[3]]),
+      INDEX_OUT_OF_BOUND_ERR
+      );
+
+      // fails as controller is not called (rejected by clawback)
+      assert.throws(() =>
+        runtime.executeTx([txGroup[1], txGroup[2], txGroup[3]]),
+      REJECTED_BY_LOGIC
+      );
+    });
+
+    it('should reject transfer if transaction group is valid but controller.sender is not equal to asset.sender', () => {
+      const txGroup = [...tokenTransferGroup];
+      txGroup[0].fromAccount = elon.account;
+
+      assert.throws(() =>
+        runtime.executeTx(txGroup),
+      RUNTIME_ERR1009
+      );
+    });
+
+    it('should reject transfer if sender trying to transfer token using secret key instead of clawback', () => {
+      const assetTransferParams = {
+        type: types.TransactionType.TransferAsset,
+        sign: types.SignType.SecretKey,
+        fromAccount: bob.account,
+        toAccountAddr: elon.address,
+        amount: 20n,
+        assetID: assetIndex,
+        payFlags: {}
+      };
+
+      // should fail as we can only use clawback (since asset is default-frozen)
+      assert.throws(() =>
+        runtime.executeTx(assetTransferParams),
+        `RUNTIME_ERR1505: Asset index ${assetIndex} frozen for account ${bob.address}`);
+    });
+
+    it('Should reject transfer if accounts are not whitelisted', () => {
+      // Issue some tokens to sender
+      issue(runtime, asaReserve.account, bob, 150, controllerAppID, assetIndex, lsig);
+      syncAccounts();
+
+      // Fails as both sender, receiver are not whitelisted
+      assert.throws(() =>
+        transfer(runtime, bob, elon, 20, assetIndex, controllerAppID, permissionsAppId, lsig),
+      RUNTIME_ERR1009
+      );
+
+      // still fails as sender is whitelisted but receiver is not
+      whitelist(runtime, permManager.account, bob.address, permissionsAppId);
+      syncAccounts();
+      assert.throws(() =>
+        transfer(runtime, bob, elon, 20, assetIndex, controllerAppID, permissionsAppId, lsig),
+      RUNTIME_ERR1009
+      );
+
+      // passes now as both sender, receiver are whitelisted
+      whitelist(runtime, permManager.account, elon.address, permissionsAppId);
+      syncAccounts();
+      transfer(runtime, bob, elon, 20, assetIndex, controllerAppID, permissionsAppId, lsig);
+    });
+
+    it('Should reject force transfer if accounts are whitelisted but receiver balance becomes > 100', () => {
+      // Opt-In to permissions SSC & Whitelist
+      whitelist(runtime, permManager.account, elon.address, permissionsAppId);
+      whitelist(runtime, permManager.account, bob.address, permissionsAppId);
+      syncAccounts();
+
+      // Issue some tokens to sender
+      issue(runtime, asaReserve.account, bob, 150, controllerAppID, assetIndex, lsig);
+      syncAccounts();
+
+      // Fails as receiver balance becomes > 100 now
+      assert.throws(() =>
+        transfer(runtime, bob, elon, 105, assetIndex, controllerAppID, permissionsAppId, lsig),
+      RUNTIME_ERR1009
+      );
+    });
+
+    it('should reject transfer if rules are followed, but token is killed', () => {
+      // Opt-In to permissions SSC & Whitelist
+      whitelist(runtime, permManager.account, elon.address, permissionsAppId);
+      whitelist(runtime, permManager.account, bob.address, permissionsAppId);
+      syncAccounts();
+
+      // Issue some tokens to sender & kill token
+      issue(runtime, asaReserve.account, bob, 150, controllerAppID, assetIndex, lsig);
+      killToken(runtime, asaManager.account, controllerAppID);
+      syncAccounts();
+
+      // fails as accounts are whitelisted, amount is good but token is killed
+      assert.throws(() =>
+        transfer(runtime, bob, elon, 10, assetIndex, controllerAppID, permissionsAppId, lsig),
+      RUNTIME_ERR1009
+      );
+    });
+  });
+
+  describe('Update token reserve', function () {
+    let updateReserveParams;
+    this.beforeEach(() => {
+      const oldReserveAssetHolding = runtime.getAssetHolding(assetIndex, asaReserve.address);
+      const newReserveAddr = elon.address;
+      optInToASA(runtime, newReserveAddr, assetIndex);
+
+      // transaction group to update reserve account
+      updateReserveParams = [
+        {
+          type: types.TransactionType.CallNoOpSSC,
+          sign: types.SignType.SecretKey,
+          fromAccount: asaManager.account,
+          appId: controllerAppID,
+          payFlags: { totalFee: 1000 },
+          appArgs: ['str:force_transfer'],
+          foreignAssets: [assetIndex]
+        },
+        {
+          type: types.TransactionType.RevokeAsset,
+          sign: types.SignType.LogicSignature,
+          fromAccountAddr: lsig.address(),
+          recipient: newReserveAddr,
+          assetID: assetIndex,
+          revocationTarget: asaReserve.address,
+          amount: oldReserveAssetHolding.amount, // moving all tokens to new reserve
+          lsig: lsig,
+          payFlags: { totalFee: 1000 }
+        },
+        {
+          type: types.TransactionType.TransferAlgo,
+          sign: types.SignType.SecretKey,
+          fromAccount: asaManager.account,
+          toAccountAddr: lsig.address(),
+          amountMicroAlgos: 1000,
+          payFlags: { totalFee: 1000 }
+        },
+        {
+          type: types.TransactionType.ModifyAsset,
+          sign: types.SignType.SecretKey,
+          fromAccount: asaManager.account,
+          assetID: assetIndex,
+          fields: {
+            manager: asaDef.manager,
+            reserve: newReserveAddr,
+            freeze: asaDef.freeze,
+            clawback: lsig.address()
+          },
+          payFlags: { totalFee: 1000 }
+        }
+      ];
+    });
+
+    it('Should fail if transaction group is not valid', () => {
+      const txGroup = [...updateReserveParams];
+
+      // fails as paying fees of clawback-escrow is skipped
+      assert.throws(() =>
+        runtime.executeTx([txGroup[0], txGroup[1], txGroup[3]]),
+      INDEX_OUT_OF_BOUND_ERR
+      );
+
+      // fails as controller is not called (rejected by clawback)
+      assert.throws(() =>
+        runtime.executeTx([txGroup[1], txGroup[2], txGroup[3]]),
+      REJECTED_BY_LOGIC
+      );
+    });
+
+    it('should reject update if controller.sender is not asset manager', () => {
+      const txGroup = [...updateReserveParams];
+      txGroup[0].fromAccount = bob.account;
+
+      // fails as controller's sender is not asset manager
+      assert.notEqual(asaManager.address, bob.address);
+      assert.throws(() =>
+        runtime.executeTx(txGroup),
+      RUNTIME_ERR1009
+      );
+    });
+
+    it('should reject update if sender of asset config tx is not asset manager', () => {
+      const txGroup = [...updateReserveParams];
+      txGroup[3].fromAccount = bob.account;
+
+      // fails as controller's sender is not asset manager
+      assert.notEqual(asaManager.address, bob.address);
+      assert.throws(() =>
+        runtime.executeTx(txGroup),
+        `RUNTIME_ERR1504: Only Manager account ${asaManager.address} can modify asset`
+      );
+    });
+  });
+});

--- a/examples/permissioned-token/test/happy-paths.js
+++ b/examples/permissioned-token/test/happy-paths.js
@@ -1,0 +1,339 @@
+const { types } = require('@algo-builder/runtime');
+const { encodeAddress } = require('algosdk');
+const { assert } = require('chai');
+const {
+  optInToASA,
+  optInToPermissionsSSC,
+  issue,
+  whitelist,
+  fund,
+  killToken,
+  transfer,
+  optOut,
+  forceTransfer,
+  setupEnv
+} = require('./common');
+
+describe('Permissioned Token Tests - Happy Paths', function () {
+  let runtime, master, alice, bob, elon;
+  let lsig, assetIndex, controllerAppID, permissionsAppId;
+  let asaDef, asaReserve, asaManager, asaCreator;
+
+  function syncAccounts () {
+    master = runtime.getAccount(master.address);
+    alice = runtime.getAccount(alice.address);
+    bob = runtime.getAccount(bob.address);
+    elon = runtime.getAccount(elon.address);
+  }
+
+  // Create Accounts and Env
+  function _setupEnv () {
+    [
+      runtime,
+      master,
+      alice,
+      bob,
+      elon,
+      assetIndex,
+      controllerAppID,
+      lsig,
+      permissionsAppId
+    ] = setupEnv();
+  }
+
+  this.beforeEach(async function () {
+    _setupEnv();
+    asaDef = runtime.getAssetDef(assetIndex);
+    asaReserve = runtime.getAccount(asaDef.reserve);
+    asaManager = runtime.getAccount(asaDef.manager);
+    asaCreator = runtime.getAccount(asaDef.creator);
+  });
+
+  it('should issue token if sender is token reserve', () => {
+    // Can issue after opting-in
+    optInToASA(runtime, elon.address, assetIndex);
+    const prevElonAssetHolding = runtime.getAssetHolding(assetIndex, elon.address);
+    assert.equal(prevElonAssetHolding.amount, 0n);
+
+    issue(runtime, asaReserve.account, elon, 20, controllerAppID, assetIndex, lsig);
+    syncAccounts();
+
+    assert.equal(
+      runtime.getAssetHolding(assetIndex, elon.address).amount,
+      prevElonAssetHolding.amount + 20n
+    );
+  });
+
+  it('should kill token if sender is token manager', () => {
+    assert.equal(runtime.getGlobalState(controllerAppID, 'killed'), 0n); // token not killed
+
+    // kill token
+    killToken(runtime, asaManager.account, controllerAppID);
+    syncAccounts();
+
+    assert.equal(runtime.getGlobalState(controllerAppID, 'killed'), 1n); // verify token is killed
+    // issuance fails now (as token is killed)
+    assert.throws(() =>
+      issue(runtime, asaReserve.account, elon, 20, controllerAppID, assetIndex, lsig),
+    'RUNTIME_ERR1009: TEAL runtime encountered err opcode');
+  });
+
+  it('should whitelist account if sender is permissions manager', () => {
+    // opt-in to permissions ssc by elon
+    optInToPermissionsSSC(runtime, elon.address, permissionsAppId);
+    syncAccounts();
+    assert.isDefined(elon.getAppFromLocal(permissionsAppId)); // verify opt-in
+
+    const permManagerAddr = encodeAddress(runtime.getGlobalState(permissionsAppId, 'manager'));
+    const permManager = runtime.getAccount(permManagerAddr);
+    whitelist(runtime, permManager.account, elon.address, permissionsAppId); // whitelist elon
+    syncAccounts();
+    assert.equal(elon.getLocalState(permissionsAppId, 'whitelisted'), 1n);
+  });
+
+  it('should opt-out of token successfully (using closeRemainderTo)', () => {
+    // Opt-In
+    optInToASA(runtime, elon.address, assetIndex);
+    issue(runtime, asaReserve.account, elon, 20, controllerAppID, assetIndex, lsig);
+    syncAccounts();
+    // verify issuance
+    assert.equal(
+      runtime.getAssetHolding(assetIndex, elon.address).amount,
+      20n
+    );
+
+    // opt-out issued tokens to creator
+    const initialCreatorHolding = runtime.getAssetHolding(assetIndex, asaCreator.address);
+    optOut(runtime, asaCreator.address, elon.account, assetIndex);
+    syncAccounts();
+
+    // verify elon and creator's asset holding (after opting out)
+    assert.equal(runtime.getAssetHolding(assetIndex, elon.address).amount, 0n);
+    assert.equal(
+      runtime.getAssetHolding(assetIndex, asaCreator.address).amount,
+      initialCreatorHolding.amount + 20n);
+  });
+
+  it('should change Permissions SSC Manager if sender is current_permissions_manager', () => {
+    // throws error as elon is not permissions manager
+    assert.throws(() =>
+      whitelist(runtime, elon.account, bob.address, permissionsAppId),
+    'RUNTIME_ERR1009: TEAL runtime encountered err opcode');
+
+    const permManagerAddr = encodeAddress(runtime.getGlobalState(permissionsAppId, 'manager'));
+    const currentPermManager = runtime.getAccount(permManagerAddr);
+    assert.notEqual(elon.address, currentPermManager.address); // verify elon is not current_perm_manager
+    const txn = {
+      type: types.TransactionType.CallNoOpSSC,
+      sign: types.SignType.SecretKey,
+      fromAccount: currentPermManager.account, // perm_manager account
+      appId: permissionsAppId,
+      payFlags: { totalFee: 1000 },
+      appArgs: ['str:change_permissions_manager'],
+      accounts: [elon.address]
+    };
+
+    // works as fromAccount is the current permissions manager
+    runtime.executeTx(txn);
+    syncAccounts();
+
+    const newPermManager = encodeAddress(runtime.getGlobalState(permissionsAppId, 'manager'));
+    assert.equal(newPermManager, elon.address); // verify new perm manager is elon
+    whitelist(runtime, elon.account, bob.address, permissionsAppId); // passes now
+
+    syncAccounts();
+    assert.equal(bob.getLocalState(permissionsAppId, 'whitelisted'), 1n);
+  });
+
+  it('should force transfer tokens between non reserve accounts successfully if sender is token manager', () => {
+    const permManagerAddr = encodeAddress(runtime.getGlobalState(permissionsAppId, 'manager'));
+    const permManager = runtime.getAccount(permManagerAddr);
+    whitelist(runtime, permManager.account, elon.address, permissionsAppId);
+    whitelist(runtime, permManager.account, bob.address, permissionsAppId);
+    syncAccounts();
+
+    // Opt-In to ASA
+    optInToASA(runtime, bob.address, assetIndex);
+    optInToASA(runtime, elon.address, assetIndex);
+    syncAccounts();
+
+    // Issue some tokens to sender
+    issue(runtime, asaReserve.account, bob, 150, controllerAppID, assetIndex, lsig);
+    syncAccounts();
+
+    // Successful transfer
+    const initialElonBalance = runtime.getAssetHolding(assetIndex, elon.address).amount;
+    const initialBobBalance = runtime.getAssetHolding(assetIndex, bob.address).amount;
+    forceTransfer(runtime, bob, elon, 20, assetIndex,
+      controllerAppID, permissionsAppId, lsig, asaManager.account);
+    // verify transfer
+    assert.equal(
+      runtime.getAssetHolding(assetIndex, bob.address).amount,
+      initialBobBalance - 20n
+    );
+    assert.equal(
+      runtime.getAssetHolding(assetIndex, elon.address).amount,
+      initialElonBalance + 20n
+    );
+  });
+
+  it('should force transfer tokens without permission checks if receiver is asset reserve', () => {
+    // Opt-In to ASA
+    optInToASA(runtime, bob.address, assetIndex);
+    optInToASA(runtime, elon.address, assetIndex);
+    syncAccounts();
+
+    // Issue few tokens to sender
+    issue(runtime, asaReserve.account, bob, 150, controllerAppID, assetIndex, lsig);
+    syncAccounts();
+
+    // note that call to permissions is not there
+    const forceTxParams = [
+      {
+        type: types.TransactionType.CallNoOpSSC,
+        sign: types.SignType.SecretKey,
+        fromAccount: asaManager.account,
+        appId: controllerAppID,
+        payFlags: { totalFee: 1000 },
+        appArgs: ['str:force_transfer'],
+        foreignAssets: [assetIndex]
+      },
+      {
+        type: types.TransactionType.RevokeAsset,
+        sign: types.SignType.LogicSignature,
+        fromAccountAddr: lsig.address(),
+        recipient: asaReserve.address,
+        assetID: assetIndex,
+        revocationTarget: bob.address,
+        amount: 20n,
+        lsig: lsig,
+        payFlags: { totalFee: 1000 }
+      },
+      {
+        type: types.TransactionType.TransferAlgo,
+        sign: types.SignType.SecretKey,
+        fromAccount: asaManager.account,
+        toAccountAddr: lsig.address(),
+        amountMicroAlgos: 1000,
+        payFlags: { totalFee: 1000 }
+      }
+    ];
+    // Successful transfer
+    const initialBobBalance = runtime.getAssetHolding(assetIndex, bob.address).amount;
+    const initialReserveBalance = runtime.getAssetHolding(assetIndex, asaReserve.address).amount;
+    runtime.executeTx(forceTxParams);
+    // verify transfer
+    assert.equal(
+      runtime.getAssetHolding(assetIndex, bob.address).amount,
+      initialBobBalance - 20n
+    );
+    assert.equal(
+      runtime.getAssetHolding(assetIndex, asaReserve.address).amount,
+      initialReserveBalance + 20n
+    );
+  });
+
+  it('should transfer tokens between non reserve accounts successfully', () => {
+    fund(runtime, master, lsig.address());
+    syncAccounts();
+    const amount = 20n;
+
+    // Issue some tokens to Bob and Elon
+    optInToASA(runtime, elon.address, assetIndex);
+    optInToASA(runtime, bob.address, assetIndex);
+    syncAccounts();
+
+    issue(runtime, asaReserve.account, elon, 50, controllerAppID, assetIndex, lsig);
+    issue(runtime, asaReserve.account, bob, 50, controllerAppID, assetIndex, lsig);
+    syncAccounts();
+
+    // whitelisted both accounts
+    const permManagerAddr = encodeAddress(runtime.getGlobalState(permissionsAppId, 'manager'));
+    const permManager = runtime.getAccount(permManagerAddr);
+    whitelist(runtime, permManager.account, elon.address, permissionsAppId);
+    whitelist(runtime, permManager.account, bob.address, permissionsAppId);
+    syncAccounts();
+    // verify accounts are whitelisted
+    assert.equal(elon.getLocalState(permissionsAppId, 'whitelisted'), 1n);
+    assert.equal(bob.getLocalState(permissionsAppId, 'whitelisted'), 1n);
+
+    // transfer 20 tokens from bob -> elon
+    const initialElonBalance = runtime.getAssetHolding(assetIndex, elon.address).amount;
+    const initialBobBalance = runtime.getAssetHolding(assetIndex, bob.address).amount;
+    transfer(runtime, bob, elon, amount, assetIndex, controllerAppID, permissionsAppId, lsig);
+    syncAccounts();
+    assert.equal(
+      runtime.getAssetHolding(assetIndex, bob.address).amount,
+      initialBobBalance - amount
+    );
+    assert.equal(
+      runtime.getAssetHolding(assetIndex, elon.address).amount,
+      initialElonBalance + amount
+    );
+  });
+
+  it('should update asset reserve account to another address if sender is asset manager', () => {
+    const oldReserveAssetHolding = runtime.getAssetHolding(assetIndex, asaReserve.address);
+    const newReserveAddr = elon.address;
+    assert.notEqual(asaReserve.address, newReserveAddr); // verify old reserve is not elon.addr
+
+    const updateReserveParams = [
+      {
+        type: types.TransactionType.CallNoOpSSC,
+        sign: types.SignType.SecretKey,
+        fromAccount: asaManager.account,
+        appId: controllerAppID,
+        payFlags: { totalFee: 1000 },
+        appArgs: ['str:force_transfer'],
+        foreignAssets: [assetIndex]
+      },
+      {
+        type: types.TransactionType.RevokeAsset,
+        sign: types.SignType.LogicSignature,
+        fromAccountAddr: lsig.address(),
+        recipient: newReserveAddr,
+        assetID: assetIndex,
+        revocationTarget: asaReserve.address,
+        amount: oldReserveAssetHolding.amount, // moving all tokens to new reserve
+        lsig: lsig,
+        payFlags: { totalFee: 1000 }
+      },
+      {
+        type: types.TransactionType.TransferAlgo,
+        sign: types.SignType.SecretKey,
+        fromAccount: asaManager.account,
+        toAccountAddr: lsig.address(),
+        amountMicroAlgos: 1000,
+        payFlags: { totalFee: 1000 }
+      },
+      {
+        type: types.TransactionType.ModifyAsset,
+        sign: types.SignType.SecretKey,
+        fromAccount: asaManager.account,
+        assetID: assetIndex,
+        fields: {
+          manager: asaDef.manager,
+          reserve: newReserveAddr,
+          freeze: asaDef.freeze,
+          clawback: lsig.address()
+        },
+        payFlags: { totalFee: 1000 }
+      }
+    ];
+
+    optInToASA(runtime, newReserveAddr, assetIndex); // opt-in to ASA by new reserve
+    const intialElonHolding = runtime.getAssetHolding(assetIndex, newReserveAddr);
+
+    // execute update tx
+    runtime.executeTx(updateReserveParams);
+    syncAccounts();
+
+    // verify asa.reserve is updated & old reserve amount is transferred to new reserve
+    const newASADef = runtime.getAssetDef(assetIndex);
+    assert.equal(newASADef.reserve, elon.address);
+    assert.equal(
+      runtime.getAssetHolding(assetIndex, elon.address).amount,
+      intialElonHolding.amount + oldReserveAssetHolding.amount
+    );
+  });
+});

--- a/packages/runtime/src/ctx.ts
+++ b/packages/runtime/src/ctx.ts
@@ -164,6 +164,8 @@ export class Ctx implements Context {
     toAssetHolding.amount += txnParam.amount;
 
     if (txnParam.payFlags.closeRemainderTo) {
+      this.assertAssetNotFrozen(txnParam.assetID as number, txnParam.payFlags.closeRemainderTo);
+
       const closeRemToAssetHolding = this.getAssetHolding(
         txnParam.assetID as number, txnParam.payFlags.closeRemainderTo);
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -6,8 +6,8 @@ import { loadASAFile, overrideASADef, validateASADefs } from "./lib/asa";
 import { loadFromYamlFileSilent, loadFromYamlFileSilentWithMessage } from "./lib/files";
 import { addressToPk, parseSSCAppArgs, stringToBytes, uint64ToBigEndian } from "./lib/parsing";
 import { encodeNote, getFromAddress, mkTransaction } from "./lib/txn";
-import { Runtime } from "./runtime";
 import { parser } from "./parser/parser";
+import { Runtime } from "./runtime";
 import * as types from "./types";
 
 export {

--- a/packages/runtime/src/lib/txn.ts
+++ b/packages/runtime/src/lib/txn.ts
@@ -52,7 +52,7 @@ export function txnSpecbyField (txField: string, tx: Txn, gtxns: Txn[], tealVers
   if (assetTxnFields.has(txField)) {
     const s = TxnFields[tealVersion][txField];
     const assetMetaData = tx.apar;
-    result = assetMetaData[s as keyof AssetDefEnc];
+    result = assetMetaData?.[s as keyof AssetDefEnc];
     return parseToStackElem(result, txField);
   }
 


### PR DESCRIPTION
- Happy Paths
    ✓ should issue token if sender is token reserve
    ✓ should kill token if sender is token manager
    ✓ should whitelist account if sender is permissions manager
    ✓ should opt-out of token successfully (using closeRemainderTo)
    ✓ should change Permissions SSC Manager if sender is current_permissions_manager
    ✓ should force transfer tokens between non reserve accounts successfully if sender is token manager
    ✓ should force transfer tokens without permission checks if receiver is asset reserve
    ✓ should transfer tokens between non reserve accounts successfully
    ✓ should update asset reserve account to another address if sender is asset manager

- Failing Paths
    - *Token Issuance*
      ✓ should not issue token if receiver is not opted in
      ✓ should not issue if token is killed
      ✓ should reject issuance tx if sender is not token reserve
      ✓ should reject issuance tx if trying to send asset using secret key instead of clawback
   - *Kill Token*
      ✓ should reject tx to kill token if sender is not token manager
   - *WhiteListing*
      ✓ should reject whitelist if account is not opted in to permissions
      ✓ should not whitelist account if sender is not current permissions manager
   - *Opt Out*
      ✓ should reject tx if user not opted-in
  -  *Change Permissions Manager*
      ✓ should fail if sender is not current permissions manager
  -  *Force Transfer(Clawback)*
      ✓ Should fail on force transfer if transaction group is not valid
      ✓ should reject transfer if transaction group is valid but controller.sender is not equal to asset.sender
      ✓ Should reject transfer is sender is not token manager
      ✓ Should reject force transfer if accounts are not whitelisted
      ✓ Should reject force transfer if accounts are whitelisted but receiver balance becomes > 100
      ✓ Should reject force transfer if token is killed
  -  *Token Transfer*
      ✓ Should fail if transaction group is not valid
      ✓ should reject transfer if transaction group is valid but controller.sender is not equal to asset.sender
      ✓ should reject transfer if sender trying to transfer token using secret key instead of clawback
      ✓ Should reject transfer if accounts are not whitelisted
      ✓ Should reject force transfer if accounts are whitelisted but receiver balance becomes > 100
      ✓ should reject transfer if rules are followed, but token is killed
  -  *Update token reserve*
      ✓ Should fail if transaction group is not valid
      ✓ should reject update if controller.sender is not asset manager
      ✓ should reject update if sender of asset config tx is not asset manager
