### PR TITLE
Fix asset transfer transaction in runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Bug fixes
 
+`@algorand-builder/runtime`
+    * Remove asset holding from account if `closeRemainderTo` is specified.
+    * Asset creator should not be able to close it's holding to another account.
 
 ## v1.0.2 2021-05-18
 

--- a/examples/permissioned-token/test/happy-paths.js
+++ b/examples/permissioned-token/test/happy-paths.js
@@ -85,7 +85,7 @@ describe('Permissioned Token Tests - Happy Paths', function () {
     ctx.syncAccounts();
 
     // verify elon and creator's asset holding (after opting out)
-    assert.equal(ctx.getAssetHolding(elon.address).amount, 0n);
+    assert.isUndefined(ctx.elon.getAssetHolding(ctx.assetIndex)); // verify asset closed from elon account
     assert.equal(
       ctx.getAssetHolding(asaCreator.address).amount,
       initialCreatorHolding.amount + 20n);

--- a/packages/runtime/src/ctx.ts
+++ b/packages/runtime/src/ctx.ts
@@ -164,13 +164,17 @@ export class Ctx implements Context {
     toAssetHolding.amount += txnParam.amount;
 
     if (txnParam.payFlags.closeRemainderTo) {
-      this.assertAssetNotFrozen(txnParam.assetID as number, txnParam.payFlags.closeRemainderTo);
+      const closeToAddr = txnParam.payFlags.closeRemainderTo;
+      if (fromAccountAddr === fromAssetHolding.creator) {
+        throw new RuntimeError(RUNTIME_ERRORS.ASA.CANNOT_CLOSE_ASSET_BY_CREATOR);
+      }
+      this.assertAssetNotFrozen(txnParam.assetID as number, closeToAddr);
 
       const closeRemToAssetHolding = this.getAssetHolding(
-        txnParam.assetID as number, txnParam.payFlags.closeRemainderTo);
+        txnParam.assetID as number, closeToAddr);
 
       closeRemToAssetHolding.amount += fromAssetHolding.amount; // transfer assets of sender to closeRemTo account
-      fromAssetHolding.amount = 0n; // close sender's account
+      this.getAccount(fromAccountAddr).assets.delete(txnParam.assetID as number); // remove asset holding from sender account
     }
   }
 

--- a/packages/runtime/src/errors/errors-list.ts
+++ b/packages/runtime/src/errors/errors-list.ts
@@ -391,6 +391,12 @@ const runtimeAsaErrors = {
     message: `Assetholding of account cannot be closed by clawback`,
     title: "Close asset by clawback error",
     description: "Clawback cannot close asset holding from an algorand account. Only the actual owner of that account can. Read more about asset parameters at https://developer.algorand.org/docs/features/asa/#asset-parameters"
+  },
+  CANNOT_CLOSE_ASSET_BY_CREATOR: {
+    number: 1510,
+    message: `Assetholding of creator account cannot be closed to another account`,
+    title: "Cannot close asset ID in allocating account",
+    description: "Asset holding of Asset creator cannot be closed to other account"
   }
 };
 


### PR DESCRIPTION
* Remove asset holding from account if `closeRemainderTo` is specified.
* Asset creator should not be able to close it's holding to another account.