### PR TITLE
Fix types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 + Move Error lists, BuilderError, mkTransaction to web package
 + Reuse mkTransaction, Errors in algob and runtime
 + Updated `algob init` to initialize a typescript project as well by passing `--typescript` flag. Usage: `algob init <location> --typescript`.
++ Fix Sign type
 
 ### Infrastructure
 * Added new make commands:

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -133,6 +133,7 @@ interface SignWithSk {
 
 interface SignWithLsig {
   sign: SignType.LogicSignature
+  fromAccount?: AccountSDK
   fromAccountAddr: AccountAddress
   lsig: LogicSig
   /** stateless smart contract args */


### PR DESCRIPTION
Closes #409 

## Proposed Changes

+ fix sign type

User is not able to reassign `fromAccount` because it doesn't exist in both `SignWithSk` and `SignWithLsig`.
Tried using: convert type to interface but this doen't work and it also breaks different address and different signing feature
Tried second method which is in this PR
