### PR TITLE
Update implementation & guide for debugging stateful teal

### DIFF
--- a/docs/guide/debugging-teal.md
+++ b/docs/guide/debugging-teal.md
@@ -198,7 +198,7 @@ In this section we will try to debug a stateful transaction (in a group) in [`/e
 
 There are 2 smart contracts (1 stateful & 1 stateless):
   * `poi-approval.teal`: Asserts a minimum level(stored in global state) set of a user. Rejects if assertion is failed.
-  * `clawback-escrow.py`: Asset clawback that is a stateless contract. Transfer assets if transaction is approved.
+  * `clawback-escrow.py`: A clawback account that is a stateless contract (lsig).
 For more details, check the project [README](https://github.com/scale-it/algo-builder/blob/master/examples/permissioned-token-freezing/README.md).
 
 Setting up transaction group:
@@ -248,9 +248,9 @@ const txGroup = [
 ```
 
 In this group:
-  * _tx0_ is an application call tx which checks minimum level set of an account(in local state)
-  * _tx1_ is an asset transfer transaction using a clawbackLsig (contract account)
-  * _tx2_ is an algotransfer transaction to pay fees of _tx1_
+  * _tx0_ is an application call which checks minimum level of an account (in local state)
+  * _tx1_ is an asset transfer transaction using a clawback lsig (_clawback-escrow.py_)
+  * _tx2_ is an algo transfer transaction to pay fees of _tx1_
 
 NOTE: Account's level can be set by executing [/permissioned-token-freezing/scripts/transfer/set-clear-level.js](https://github.com/scale-it/algo-builder/blob/master/examples/permissioned-token-freezing/scripts/transfer/set-clear-level.js). If a min level is set, then the dry run transaction will _PASS_, otherwise the "app-call-messages" would be _REJECT_.
 
@@ -272,7 +272,7 @@ To debug a specific transaction in a group, pass the `groupIndex` parameter. Let
 await debug.run({ tealFile: "poi-approval.teal", groupIndex: 0 });
 ```
 
-That's it, above code will start a live debugging session.
+That's it, the code above will start a live debugging session.
 ![image](https://user-images.githubusercontent.com/33264364/127727303-72f9e91d-1013-46f7-a8ba-e2862e723608.png)
 Notice that in `Scope` we have `appGlobal`, `appLocals` as we upload the applications and ledger state while construcing request for `tealdbg debug`.
 

--- a/docs/guide/debugging-teal.md
+++ b/docs/guide/debugging-teal.md
@@ -190,7 +190,7 @@ Now, we have a remote target set up in `chrome://inspect`
 Click on **inspect** and start playing with the teal code!
 ![image](https://user-images.githubusercontent.com/33264364/125868869-b55f8e4e-71e9-4742-91b9-75d56bf333d6.png)
 
-Script used in this walkthrough is `gold-delegated-lsig.debug.js` and can be found [here](https://github.com/scale-it/algo-builder/blob/support-tealdbg/examples/asa/scripts/transfer/gold-delegated-lsig.debug.js).
+Script used in this walkthrough is `gold-delegated-lsig.debug.js` and can be found [here](https://github.com/scale-it/algo-builder/blob/develop/examples/asa/scripts/transfer/gold-delegated-lsig.debug.js).
 
 ## Example Walkthrough (Stateful TEAL)
 
@@ -285,3 +285,5 @@ await debug.run({
 });
 ```
 ![image](https://user-images.githubusercontent.com/33264364/127727690-195c2e5f-c50d-456c-8948-3b076ba119b2.png)
+
+This walkthrough can be found in [`/examples/permissioned-token-freezing/scripts/transfer/transfer-asset.debug.js`](https://github.com/scale-it/algo-builder/blob/develop/examples/permissioned-token-freezing/scripts/transfer/transfer-asset.debug.js)

--- a/docs/guide/debugging-teal.md
+++ b/docs/guide/debugging-teal.md
@@ -47,7 +47,7 @@ await debugger.run({ tealFile: '4-gold-asa.teal' }); // 4-gold-asa.teal present 
 
 NOTE: To configure the chrome listener for a debugging session, read [Configure the Listener](https://github.com/algorand/go-algorand/blob/master/cmd/tealdbg/README.md#configure-the-listener).
 
-## Example Walkthrough
+## Example Walkthrough (Stateless TEAL)
 
 In this section we will try to debug a stateless transaction in [`/examples/asa`](https://github.com/scale-it/algo-builder/tree/master/examples/asa).
 
@@ -191,3 +191,97 @@ Click on **inspect** and start playing with the teal code!
 ![image](https://user-images.githubusercontent.com/33264364/125868869-b55f8e4e-71e9-4742-91b9-75d56bf333d6.png)
 
 Script used in this walkthrough is `gold-delegated-lsig.debug.js` and can be found [here](https://github.com/scale-it/algo-builder/blob/support-tealdbg/examples/asa/scripts/transfer/gold-delegated-lsig.debug.js).
+
+## Example Walkthrough (Stateful TEAL)
+
+In this section we will try to debug a stateful transaction (in a group) in [`/examples/permissioned-token-freezing`](https://github.com/scale-it/algo-builder/tree/master/examples/permissioned-token-freezing).
+
+There are 2 smart contracts (1 stateful & 1 stateless):
+  * `poi-approval.teal`: Asserts a minimum level(stored in global state) set of a user. Rejects if assertion is failed.
+  * `clawback-escrow.py`: Asset clawback that is a stateless contract. Transfer assets if transaction is approved.
+For more details, check the project [README](https://github.com/scale-it/algo-builder/blob/master/examples/permissioned-token-freezing/README.md).
+
+Setting up transaction group:
+```js
+// load app, asset info from checkpoint
+const appInfo = deployer.getApp('poi-approval.teal', 'poi-clear.teal');
+const assetInfo = deployer.asa.get('gold');
+
+// load logic signature
+const escrowParams = {
+  ASSET_ID: assetInfo.assetIndex,
+  APP_ID: appInfo.appID
+};
+const escrowLsig = await deployer.loadLogic('clawback-escrow.py', escrowParams);
+const escrowAddress = escrowLsig.address();
+
+const txGroup = [
+  {
+    type: types.TransactionType.CallNoOpSSC,
+    sign: types.SignType.SecretKey,
+    fromAccount: creator,
+    appID: appInfo.appID,
+    payFlags: { totalFee: 1000 },
+    appArgs: ['str:check-level'],
+    accounts: [bob.addr] //  AppAccounts
+  },
+  {
+    type: types.TransactionType.RevokeAsset,
+    sign: types.SignType.LogicSignature,
+    fromAccountAddr: escrowAddress,
+    recipient: bob.addr,
+    assetID: assetInfo.assetIndex,
+    revocationTarget: creator.addr,
+    amount: 1000,
+    lsig: escrowLsig,
+    payFlags: { totalFee: 1000 }
+  },
+  {
+    type: types.TransactionType.TransferAlgo,
+    sign: types.SignType.SecretKey,
+    fromAccount: creator,
+    toAccountAddr: escrowAddress,
+    amountMicroAlgos: 1000,
+    payFlags: { totalFee: 1000 }
+  }
+];
+```
+
+In this group:
+  * _tx0_ is an application call tx which checks minimum level set of an account(in local state)
+  * _tx1_ is an asset transfer transaction using a clawbackLsig (contract account)
+  * _tx2_ is an algotransfer transaction to pay fees of _tx1_
+
+NOTE: Account's level can be set by executing [/permissioned-token-freezing/scripts/transfer/set-clear-level.js](https://github.com/scale-it/algo-builder/blob/master/examples/permissioned-token-freezing/scripts/transfer/set-clear-level.js). If a min level is set, then the dry run transaction will _PASS_, otherwise the "app-call-messages" would be _REJECT_.
+
+### Dry Run
+
+To get dry run response of the transaction group, simply do:
+```js
+// reponse is dumped to assets/dryrun.json
+await debug.dryRunResponse('dryrun.json');
+```
+
+The dry run response has all 3 txns, with "app-call-messages"(PASS/REJECT) for _tx0_, and "logic-sig-messages" for _tx1_. Response will be `null` for _tx2_ (as this is a simple algo transfer tx).
+As explained above, the message could be PASS/REJECT depending on the minlevel set.
+
+### Start Debugger
+
+To debug a specific transaction in a group, pass the `groupIndex` parameter. Let's try to start the debugger for _tx0_:
+```js
+await debug.run({ tealFile: "poi-approval.teal", groupIndex: 0 });
+```
+
+That's it, above code will start a live debugging session.
+![image](https://user-images.githubusercontent.com/33264364/127727303-72f9e91d-1013-46f7-a8ba-e2862e723608.png)
+Notice that in `Scope` we have `appGlobal`, `appLocals` as we upload the applications and ledger state while construcing request for `tealdbg debug`.
+
+To debug 2nd transaction (clawbackLsig) in group, update the `tealFile` & `groupIndex`:
+```js
+await debug.run({
+  tealFile: "clawback-escrow.py",
+  scInitParam: escrowParams, // template paramters to pyTEAL file
+  groupIndex: 1 // pass index of transaction to debug
+});
+```
+![image](https://user-images.githubusercontent.com/33264364/127727690-195c2e5f-c50d-456c-8948-3b076ba119b2.png)

--- a/examples/asa/scripts/transfer/gold-delegated-lsig.debug.js
+++ b/examples/asa/scripts/transfer/gold-delegated-lsig.debug.js
@@ -40,13 +40,14 @@ async function run (runtimeEnv, deployer) {
   await debug.dryRunResponse('dryrun-fail.json', true); // passing true overwrites existing .json file
 
   /* uncomment below line to start debugger for failing scenario */
-  // await debug.run({ tealFile: "4-gold-asa.teal" });
+  await debug.run({ tealFile: '4-gold-asa.py' });
 
   // setting transaction group in execParams
   // notice that in debugger session Scope.gtxn has 2 transactions
   debug.execParams = [
     mkParam(masterAccount, john.addr, 4e6, {}),
-    txnParam
+    txnParam,
+    { ...txnParam, amount: 1500 }
   ];
   // await debug.run({ tealFile: "4-gold-asa.teal", groupIndex: 1 });
 }

--- a/examples/permissioned-token-freezing/scripts/transfer/set-clear-level.js
+++ b/examples/permissioned-token-freezing/scripts/transfer/set-clear-level.js
@@ -27,6 +27,10 @@ async function run (runtimeEnv, deployer) {
     accounts: [bob.addr]
   });
 
+  /* uncomment below code to debug (start a debugging session) line 24 */
+  // await new Tealdbg(deployer, setLevelParams)
+  // .run({ tealFile: 'poi-approval.teal' });
+
   /* Use below code to clear the min asset level set
     const clearLevelParams = {
       type: types.TransactionType.CallNoOpSSC,

--- a/examples/permissioned-token-freezing/scripts/transfer/transfer-asset.debug.js
+++ b/examples/permissioned-token-freezing/scripts/transfer/transfer-asset.debug.js
@@ -21,7 +21,7 @@ async function run (runtimeEnv, deployer) {
   const escrowAddress = escrowLsig.address();
 
   const txGroup = [
-    // NOTE: tx0 will fail if minimum accred level is not set
+    // NOTE: tx0 will fail if an account level is below level or not set
     // (i.e script ./set-clear-level.js is not executed)
     {
       type: types.TransactionType.CallNoOpSSC,
@@ -56,7 +56,7 @@ async function run (runtimeEnv, deployer) {
   console.log('* Debug ./transfer-asset.js: Transferring 1000 Assets from Alice to Bob *');
 
   const debug = new Tealdbg(deployer, txGroup);
-  await debug.dryRunResponse('dryrun.json'); // tx0 message will be "REJECT" if ./set-clear-level.js is not executed (as min level is not set)
+  await debug.dryRunResponse('dryrun.json'); // tx0 message will be "REJECT" if ./set-clear-level.js is not executed (min level is not set)
 
   // debug 1st transaction (checking min-level of an account is set)
   // await debug.run({ tealFile: "poi-approval.teal", groupIndex: 0 });

--- a/examples/stateful-counter/scripts/interaction/call_application.js
+++ b/examples/stateful-counter/scripts/interaction/call_application.js
@@ -1,4 +1,4 @@
-const { readGlobalStateSSC, executeTransaction } = require('@algo-builder/algob');
+const { readGlobalStateSSC, executeTransaction, Tealdbg } = require('@algo-builder/algob');
 const { types } = require('@algo-builder/web');
 
 async function run (runtimeEnv, deployer) {
@@ -22,6 +22,11 @@ async function run (runtimeEnv, deployer) {
   };
 
   await executeTransaction(deployer, tx);
+
+  /* Uncomment below code to start debugger  */
+  // await new Tealdbg(deployer, tx)
+  //   .run({ tealFile: "approval_program.teal" });
+
   globalState = await readGlobalStateSSC(deployer, creatorAccount.addr, applicationID);
   console.log(globalState);
 }

--- a/examples/stateful-counter/scripts/interaction/call_application.js
+++ b/examples/stateful-counter/scripts/interaction/call_application.js
@@ -1,4 +1,4 @@
-const { readGlobalStateSSC, executeTransaction, Tealdbg } = require('@algo-builder/algob');
+const { readGlobalStateSSC, executeTransaction } = require('@algo-builder/algob');
 const { types } = require('@algo-builder/web');
 
 async function run (runtimeEnv, deployer) {

--- a/packages/algob/src/lib/dryrun.ts
+++ b/packages/algob/src/lib/dryrun.ts
@@ -34,7 +34,7 @@ export class Tealdbg {
    */
   private async getAccountsForDryRun (txn: wtypes.ExecParams): Promise<modelsv2.Account[]> {
     // get addresses of Txn.Accounts (in case of stateful tx params) & Txn.Sender
-    const txAccounts = (txn as wtypes.AppCallsParam).accounts ?? [];
+    const txAccounts = (txn as wtypes.AppCallsParam).accounts ?? [];  // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
     const addrs = [...txAccounts, getFromAddress(txn)];
 
     const accountsForDryRun = [];

--- a/packages/algob/src/lib/dryrun.ts
+++ b/packages/algob/src/lib/dryrun.ts
@@ -1,6 +1,5 @@
 import { getPathFromDirRecursive, types as rtypes } from "@algo-builder/runtime";
-import { types as wtypes } from "@algo-builder/web";
-import { getFromAddress } from "@algo-builder/web/build/lib/txn";
+import { tx, types as wtypes } from "@algo-builder/web";
 import { decodeSignedTransaction, EncodedSignedTransaction, encodeObj, modelsv2 } from "algosdk";
 import { spawn } from "child_process";
 import * as fs from 'fs';
@@ -35,7 +34,7 @@ export class Tealdbg {
   private async getAccountsForDryRun (txn: wtypes.ExecParams): Promise<modelsv2.Account[]> {
     // get addresses of Txn.Accounts (in case of stateful tx params) & Txn.Sender
     const txAccounts = (txn as wtypes.AppCallsParam).accounts ?? []; // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
-    const addrs = [...txAccounts, getFromAddress(txn)];
+    const addrs = [...txAccounts, tx.getFromAddress(txn)];
 
     const accountsForDryRun = [];
     for (const addr of addrs) {

--- a/packages/algob/src/lib/dryrun.ts
+++ b/packages/algob/src/lib/dryrun.ts
@@ -34,7 +34,7 @@ export class Tealdbg {
    */
   private async getAccountsForDryRun (txn: wtypes.ExecParams): Promise<modelsv2.Account[]> {
     // get addresses of Txn.Accounts (in case of stateful tx params) & Txn.Sender
-    const txAccounts = (txn as wtypes.AppCallsParam).accounts ?? [];  // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
+    const txAccounts = (txn as wtypes.AppCallsParam).accounts ?? []; // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
     const addrs = [...txAccounts, getFromAddress(txn)];
 
     const accountsForDryRun = [];

--- a/packages/algob/src/lib/dryrun.ts
+++ b/packages/algob/src/lib/dryrun.ts
@@ -111,10 +111,9 @@ export class Tealdbg {
   /**
    * Create dry run request object using SDK transaction(s) from wtypes.ExecParams
    * User can dump the response (using this.dryRunResponse) or start debugger session
-   * @param txIndex index of transaction if a transaction group is passed. Defaults to 0.
    * @returns SDK dryrun request object
    */
-  private async createDryRunReq (txIndex?: number): Promise<modelsv2.DryrunRequest> {
+  private async createDryRunReq (): Promise<modelsv2.DryrunRequest> {
     let [_, signedTxn] = await makeAndSignTx(this.deployer, this.execParams, new Map());
     if (!Array.isArray(signedTxn)) { signedTxn = [signedTxn]; }
 

--- a/packages/algob/src/lib/dryrun.ts
+++ b/packages/algob/src/lib/dryrun.ts
@@ -123,7 +123,7 @@ export class Tealdbg {
       encodedSignedTxns.push({ ...decodedTx, txn: decodedTx.txn.get_obj_for_encoding() });
     }
 
-    // get application and accounts data/state to pass to debug session
+    // query application and account state and pass them to a debug session
     const execParamsArr = Array.isArray(this.execParams) ? this.execParams : [this.execParams];
     const appsForDryRun: modelsv2.Application[] = [];
     const accountsForDryRun: modelsv2.Account[] = [];

--- a/packages/algob/src/lib/dryrun.ts
+++ b/packages/algob/src/lib/dryrun.ts
@@ -1,5 +1,6 @@
 import { getPathFromDirRecursive, types as rtypes } from "@algo-builder/runtime";
 import { types as wtypes } from "@algo-builder/web";
+import { getFromAddress } from "@algo-builder/web/build/lib/txn";
 import { decodeSignedTransaction, EncodedSignedTransaction, encodeObj, modelsv2 } from "algosdk";
 import { spawn } from "child_process";
 import * as fs from 'fs';
@@ -10,6 +11,7 @@ import { writeToFile } from "../builtin-tasks/gen-accounts";
 import { ASSETS_DIR, CACHE_DIR } from "../internal/core/project-structure";
 import { timestampNow } from "../lib/time";
 import type { DebuggerContext, Deployer } from "../types";
+import { getProgram } from "./load-program";
 import { makeAndSignTx } from "./tx";
 
 export const tealExt = ".teal";
@@ -26,11 +28,93 @@ export class Tealdbg {
   }
 
   /**
+   * Get account state(s) (fetched using account address) for dry run.
+   * For eg. app_local_get, app_local_put requires an accounts ledger state to be uploaded.
+   * @param txn transaction parameters
+   */
+  private async getAccountsForDryRun (txn: wtypes.ExecParams): Promise<modelsv2.Account[]> {
+    // get addresses of Txn.Accounts (in case of stateful tx params) & Txn.Sender
+    const txAccounts = (txn as wtypes.AppCallsParam).accounts ?? [];
+    const addrs = [...txAccounts, getFromAddress(txn)];
+
+    const accountsForDryRun = [];
+    for (const addr of addrs) {
+      const accInfo = await this.deployer.algodClient.accountInformation(addr).do();
+      if (!accInfo) { continue; }
+
+      const acc = new modelsv2.Account({
+        address: accInfo.address,
+        amount: accInfo.amount,
+        amountWithoutPendingRewards: accInfo['amount-without-pending-rewards'],
+        appsLocalState: accInfo['apps-local-state'],
+        appsTotalSchema: accInfo['apps-total-schema'],
+        assets: accInfo.assets,
+        createdApps: accInfo['created-apps'],
+        createdAssets: accInfo['created-assets'],
+        pendingRewards: accInfo['pending-rewards'],
+        rewardBase: accInfo['reward-base'],
+        rewards: accInfo.rewards,
+        round: accInfo.round,
+        status: accInfo.status
+      });
+      accountsForDryRun.push(acc);
+    }
+    return accountsForDryRun;
+  }
+
+  /**
+   * Get application state(s) (fetched by appID) for dry run.
+   * For eg. app_global_get, app_global_put requires app state.
+   * @param txn transaction parameters
+   */
+  private async getAppsForDryRun (txn: wtypes.ExecParams): Promise<modelsv2.Application[]> {
+    if (!(
+      txn.type === wtypes.TransactionType.ClearApp ||
+      txn.type === wtypes.TransactionType.CloseApp ||
+      txn.type === wtypes.TransactionType.DeleteApp ||
+      txn.type === wtypes.TransactionType.UpdateApp ||
+      txn.type === wtypes.TransactionType.OptInToApp ||
+      txn.type === wtypes.TransactionType.CallNoOpSSC
+    )) {
+      return [];
+    }
+
+    // maybe txn.foreignApps won't work: https://github.com/algorand/go-algorand/issues/2609
+    // this would be required with app_global_get_ex ops (access external contract's state)
+    const appIDs = [...(txn.foreignApps ?? []), txn.appID];
+    const appsForDryRun = [];
+    for (const appID of appIDs) {
+      const app = await this.deployer.algodClient.getApplicationByID(appID).do();
+
+      const globalStateSchema = new modelsv2.ApplicationStateSchema(app.params['global-state-schema']['num-uint'], app.params['global-state-schema']['num-byte-slice']);
+      const localStateSchema = new modelsv2.ApplicationStateSchema(app.params['local-state-schema']['num-uint'], app.params['local-state-schema']['num-byte-slice']);
+      const globalState = (app.params['global-state'] || []).map(({ key, value }: { key: string, value: any }) => (
+        new modelsv2.TealKeyValue(key, new modelsv2.TealValue(value.type, value.bytes, value.uint))
+      ));
+
+      const appParams = new modelsv2.ApplicationParams({
+        approvalProgram: app.params['approval-program'],
+        clearStateProgram: app.params['clear-state-program'],
+        creator: app.params.creator,
+        globalState,
+        globalStateSchema,
+        localStateSchema,
+        extraProgramPages: app.params['extra-program-pages']
+      });
+      const appForDryRun = new modelsv2.Application(app.id, appParams);
+      appsForDryRun.push(appForDryRun);
+    }
+
+    return appsForDryRun;
+  }
+
+  /**
    * Create dry run request object using SDK transaction(s) from wtypes.ExecParams
    * User can dump the response (using this.dryRunResponse) or start debugger session
+   * @param txIndex index of transaction if a transaction group is passed. Defaults to 0.
    * @returns SDK dryrun request object
    */
-  private async createDryRunReq (): Promise<modelsv2.DryrunRequest> {
+  private async createDryRunReq (txIndex?: number): Promise<modelsv2.DryrunRequest> {
     let [_, signedTxn] = await makeAndSignTx(this.deployer, this.execParams, new Map());
     if (!Array.isArray(signedTxn)) { signedTxn = [signedTxn]; }
 
@@ -40,9 +124,20 @@ export class Tealdbg {
       encodedSignedTxns.push({ ...decodedTx, txn: decodedTx.txn.get_obj_for_encoding() });
     }
 
+    // get application and accounts data/state to pass to debug session
+    const execParamsArr = Array.isArray(this.execParams) ? this.execParams : [this.execParams];
+    const appsForDryRun: modelsv2.Application[] = [];
+    const accountsForDryRun: modelsv2.Account[] = [];
+    for (const e of execParamsArr) {
+      appsForDryRun.push(...(await this.getAppsForDryRun(e)));
+      accountsForDryRun.push(...(await this.getAccountsForDryRun(e)));
+    }
+
     // issue: https://github.com/algorand/js-algorand-sdk/issues/410
     // task: https://www.pivotaltracker.com/story/show/179060295
     return new (modelsv2 as any).DryrunRequest({
+      accounts: accountsForDryRun.length > 0 ? accountsForDryRun : undefined,
+      apps: appsForDryRun.length > 0 ? appsForDryRun : undefined,
       txns: encodedSignedTxns,
       sources: undefined
     });
@@ -105,8 +200,19 @@ export class Tealdbg {
 
     /* Push path of tealfile to debug. If not passed then debugger will use assembled code by default
      * Supplying the program will allow debugging the "original source" and not the decompiled version. */
-    if (debugCtxParams.tealFile) {
-      const pathToFile = getPathFromDirRecursive(ASSETS_DIR, debugCtxParams.tealFile) as string;
+    const file = debugCtxParams.tealFile;
+    if (file) {
+      let pathToFile;
+      if (file.endsWith(pyExt)) {
+        // note: currently tealdbg only accepts "teal" code, so we need to compile pyTEAL to TEAL first
+        // issue: https://github.com/algorand/go-algorand/issues/2538
+        pathToFile = path.join(CACHE_DIR, 'dryrun', path.parse(file).name + '.' + timestampNow().toString() + tealExt);
+        const tealFromPyTEAL = getProgram(file, debugCtxParams.scInitParam);
+        this.writeFile(pathToFile, tealFromPyTEAL);
+      } else {
+        pathToFile = getPathFromDirRecursive(ASSETS_DIR, file) as string;
+      }
+
       tealdbgArgs.push(pathToFile);
     }
 
@@ -121,8 +227,13 @@ export class Tealdbg {
     }
 
     // set groupIndex flag if a transaction group is passed in this.wtypes.ExecParams
-    if (debugCtxParams.groupIndex) {
-      tealdbgArgs.push('--group-index', debugCtxParams.groupIndex.toString());
+    const grpIdx = debugCtxParams.groupIndex;
+    if (grpIdx !== undefined) {
+      const execParamsArr = Array.isArray(this.execParams) ? this.execParams : [this.execParams];
+      if (grpIdx >= execParamsArr.length) {
+        throw new Error(`groupIndex(= ${grpIdx}) exceeds transaction group length(= ${execParamsArr.length})`);
+      }
+      tealdbgArgs.push('--group-index', grpIdx.toString());
     }
 
     return tealdbgArgs;
@@ -152,7 +263,7 @@ export class Tealdbg {
   }
 
   // write (dryrun dump) to file in `cache/dryrun`
-  writeFile (filename: string, content: Uint8Array): void {
+  protected writeFile (filename: string, content: Uint8Array | string): void {
     ensureDirSync(path.dirname(filename));
     fs.writeFileSync(filename, content);
   }

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -654,6 +654,7 @@ export type PromiseAny = Promise<any>; // eslint-disable-line @typescript-eslint
 
 export interface DebuggerContext {
   tealFile?: string
+  scInitParam?: unknown // if tealfile is ".py"
   groupIndex?: number
   mode?: rtypes.ExecutionMode
 }

--- a/packages/algob/test/lib/tx.ts
+++ b/packages/algob/test/lib/tx.ts
@@ -510,7 +510,7 @@ describe("Delete ASA and SSC transaction flow(with functions and executeTransact
   });
 
   it("should throw error if user tries to opt-in deleted app", async () => {
-    const execParam: wtypes.OptInToAppParam = {
+    const execParam: wtypes.AppCallsParam = {
       type: wtypes.TransactionType.OptInToApp,
       sign: wtypes.SignType.SecretKey,
       fromAccount: bobAcc,

--- a/packages/algob/test/mocks/tx.ts
+++ b/packages/algob/test/mocks/tx.ts
@@ -85,4 +85,39 @@ export const mockDryRunResponse = {
   ]
 };
 
+export const mockAccountInformation = {
+  address: 'EDXG4GGBEHFLNX6A7FGT3F6Z3TQGIU6WVVJNOXGYLVNTLWDOCEJJ35LWJY',
+  amount: 196868961,
+  'amount-without-pending-rewards': 196867197,
+  'apps-local-state': [{ id: 6, 'key-value': [], schema: [] }],
+  'apps-total-schema': { 'num-byte-slice': 1, 'num-uint': 3 },
+  assets: [
+    {
+      amount: 1000000,
+      'asset-id': 4,
+      creator: 'EDXG4GGBEHFLNX6A7FGT3F6Z3TQGIU6WVVJNOXGYLVNTLWDOCEJJ35LWJY',
+      'is-frozen': false
+    }
+  ],
+  'created-apps': [{ id: 6, params: [] }],
+  'created-assets': [{ index: 4, params: [] }],
+  'pending-rewards': 1764,
+  'reward-base': 10,
+  rewards: 1961,
+  round: 412,
+  status: 'Offline'
+};
+
+export const mockApplicationResponse = {
+  id: 6,
+  params: {
+    'approval-program': 'AiAHAAIBBAUDBiYHB0NyZWF0b3IHQXNzZXRJRApBc3NldExldmVsCXNldC1sZXZlbAVjbGVhcgtjaGVjay1sZXZlbAxBY2NyZWQtTGV2ZWwiMRgSQQAZMRsjEkEBbSgxAGcpNhoAF2cqNhoBF2ckQzEZIhJAACAxGSQSQAEzMRkjEkABOjEZJRJAATwxGSEEEkABNUIBNDEbJA8xGyMOEEEBKDYaACsSQAATNhoAJwQSQAAmNhoAJwUSQAA1ADEbIxIoZDEAEhAyBCQSEEEA+yQnBjYaARdmJEMxGyQSKGQxABIQMgQkEhBBAN8kJwZoJEMyBCEFEjMAECEGEhAzARAlEhAzAhAkEhAxFiISEEEAuTMAIDIDEjMBIDIDEhAzAiAyAxIQMwAJMgMSEDMBCTIDEhAzAgkyAxIQMwAVMgMSEDMBFTIDEhAzAhUyAxIQQQB4IillQQByNQszABgyCBIzAAAzAgASEDMAADMBExIQQQBXNwAcATMBFBIzARE0CxIQQQBFMwIIMwEBD0EAOyIzABgnBmNBADEqZA9BACskMRgnBmNBACIqZA9BABwkQzEbIhIxFiISEEEADiRDMRYiEkEABSRDACRDIkM=',
+    'clear-state-program': 'AiABASJD',
+    creator: 'EDXG4GGBEHFLNX6A7FGT3F6Z3TQGIU6WVVJNOXGYLVNTLWDOCEJJ35LWJY',
+    'global-state': [],
+    'global-state-schema': { 'num-byte-slice': 1, 'num-uint': 2 },
+    'local-state-schema': { 'num-byte-slice': 0, 'num-uint': 1 }
+  }
+};
+
 export const mockLsig: LogicSig = algosdk.makeLogicSig(mockProgram, []);

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -98,7 +98,7 @@ export interface AppOptionalFlags {
 export type ExecParams = AlgoTransferParam | AssetTransferParam | AppCallsParam |
 ModifyAssetParam | FreezeAssetParam | RevokeAssetParam |
 DestroyAssetParam | DeployASAParam | DeployAppParam |
-OptInToAppParam | OptInASAParam | UpdateAppParam;
+OptInASAParam | UpdateAppParam;
 
 export enum SignType {
   SecretKey,
@@ -174,8 +174,9 @@ export type UpdateAppParam = BasicParams & AppOptionalFlags & {
   clearProg?: Uint8Array
 };
 
-export type OptInToAppParam = BasicParams & AppOptionalFlags & {
-  type: TransactionType.OptInToApp
+export type AppCallsParam = BasicParams & AppOptionalFlags & {
+  type: TransactionType.CallNoOpSSC | TransactionType.ClearApp |
+  TransactionType.CloseApp | TransactionType.DeleteApp | TransactionType.OptInToApp
   appID: number
 };
 
@@ -225,12 +226,6 @@ export type AssetTransferParam = BasicParams & {
   toAccountAddr: AccountAddress
   amount: number | bigint
   assetID: number | string
-};
-
-export type AppCallsParam = BasicParams & AppOptionalFlags & {
-  type: TransactionType.CallNoOpSSC | TransactionType.ClearApp |
-  TransactionType.CloseApp | TransactionType.DeleteApp
-  appID: number
 };
 
 export type ASADef = z.infer<typeof ASADefSchema>;


### PR DESCRIPTION
## Proposed Changes

+ Upload applications and accounts data to `SDK.modelsv2.DryrunRequest` (used for global and local state)
+ Support debugging pyTEAL contracts
+ Added example for debugging (stateless + stateful + transfer) tx in group (added in `/examples/permissioned-token-freezing`)
+ Added Documentation