### PR TITLE
TEALv4: Sharing data between contracts in runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Improvements
++ Added shared space between contracts
++ Added tealv4 opcodes (`gload` and `gloads`) 
 ### Bug Fixes
 * Fixed `yarn add @algo-builder/web` (was failing because of missing dependency `zod` in packages/web).
 

--- a/packages/runtime/src/ctx.ts
+++ b/packages/runtime/src/ctx.ts
@@ -12,7 +12,7 @@ import {
   AppDeploymentFlags,
   ASADeploymentFlags, AssetHoldingM,
   Context, ExecutionMode,
-  SSCAttributesM, State, Txn
+  SSCAttributesM, StackElem, State, Txn
 } from "./types";
 
 const APPROVAL_PROGRAM = "approval-program";
@@ -24,6 +24,7 @@ export class Ctx implements Context {
   args: Uint8Array[];
   runtime: Runtime;
   debugStack?: number; //  max number of top elements from the stack to print after each opcode execution.
+  sharedScratchSpace: Map<number, StackElem[]>;
 
   constructor (state: State, tx: Txn, gtxs: Txn[], args: Uint8Array[],
     runtime: Runtime, debugStack?: number) {
@@ -33,6 +34,7 @@ export class Ctx implements Context {
     this.args = args;
     this.runtime = runtime;
     this.debugStack = debugStack;
+    this.sharedScratchSpace = new Map<number, StackElem[]>();
   }
 
   // verify account's balance is above minimum required balance
@@ -225,7 +227,7 @@ export class Ctx implements Context {
    */
   addApp (
     fromAccountAddr: AccountAddress, flags: AppDeploymentFlags,
-    approvalProgram: string, clearProgram: string
+    approvalProgram: string, clearProgram: string, idx?: number
   ): number {
     const senderAcc = this.getAccount(fromAccountAddr);
 
@@ -242,7 +244,9 @@ export class Ctx implements Context {
     this.state.accounts.set(senderAcc.address, senderAcc);
     this.state.globalApps.set(app.id, senderAcc.address);
 
-    this.runtime.run(approvalProgram, ExecutionMode.APPLICATION, this.debugStack); // execute TEAL code with appID = 0
+    this.runtime.run(
+      approvalProgram, ExecutionMode.APPLICATION, idx ?? 0, this.debugStack
+    ); // execute TEAL code with appID = 0
 
     // create new application in globalApps map
     this.state.globalApps.set(++this.state.appCounter, senderAcc.address);
@@ -272,13 +276,13 @@ export class Ctx implements Context {
    * @param appID Application index
    * NOTE: When creating or opting into an app, the minimum balance grows before the app code runs
    */
-  optInToApp (accountAddr: AccountAddress, appID: number): void {
+  optInToApp (accountAddr: AccountAddress, appID: number, idx?: number): void {
     const appParams = this.getApp(appID);
 
     const account = this.getAccount(accountAddr);
     account.optInToApp(appID, appParams);
     this.assertAccBalAboveMin(accountAddr);
-    this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, this.debugStack);
+    this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, idx ?? 0, this.debugStack);
   }
 
   /**
@@ -474,7 +478,8 @@ export class Ctx implements Context {
   updateApp (
     appID: number,
     approvalProgram: string,
-    clearProgram: string
+    clearProgram: string,
+    idx?: number
   ): void {
     if (approvalProgram === "") {
       throw new RuntimeError(RUNTIME_ERRORS.GENERAL.INVALID_APPROVAL_PROGRAM);
@@ -484,7 +489,7 @@ export class Ctx implements Context {
     }
 
     const appParams = this.getApp(appID);
-    this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, this.debugStack);
+    this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, idx ?? 0, this.debugStack);
 
     const updatedApp = this.getApp(appID);
     updatedApp[APPROVAL_PROGRAM] = approvalProgram;
@@ -526,13 +531,13 @@ export class Ctx implements Context {
         case types.TransactionType.CallNoOpSSC: {
           this.tx = this.gtxs[idx]; // update current tx to the requested index
           const appParams = this.getApp(txnParam.appID);
-          this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, this.debugStack);
+          this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, idx, this.debugStack);
           break;
         }
         case types.TransactionType.CloseApp: {
           this.tx = this.gtxs[idx]; // update current tx to the requested index
           const appParams = this.getApp(txnParam.appID);
-          this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, this.debugStack);
+          this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, idx, this.debugStack);
           this.closeApp(fromAccountAddr, txnParam.appID);
           break;
         }
@@ -540,7 +545,7 @@ export class Ctx implements Context {
           this.tx = this.gtxs[idx]; // update current tx to the requested index
 
           this.updateApp(
-            txnParam.appID, txnParam.newApprovalProgram, txnParam.newClearProgram
+            txnParam.appID, txnParam.newApprovalProgram, txnParam.newClearProgram, idx
           );
           break;
         }
@@ -548,7 +553,7 @@ export class Ctx implements Context {
           this.tx = this.gtxs[idx]; // update current tx to the requested index
           const appParams = this.runtime.assertAppDefined(txnParam.appID, this.getApp(txnParam.appID));
           try {
-            this.runtime.run(appParams["clear-state-program"], ExecutionMode.APPLICATION, this.debugStack);
+            this.runtime.run(appParams["clear-state-program"], ExecutionMode.APPLICATION, idx, this.debugStack);
           } catch (error) {
             // if transaction type is Clear Call, remove the app without throwing error (rejecting tx)
             // tested by running on algorand network
@@ -561,7 +566,7 @@ export class Ctx implements Context {
         case types.TransactionType.DeleteApp: {
           this.tx = this.gtxs[idx]; // update current tx to the requested index
           const appParams = this.getApp(txnParam.appID);
-          this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, this.debugStack);
+          this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, idx, this.debugStack);
           this.deleteApp(txnParam.appID);
           break;
         }
@@ -637,14 +642,15 @@ export class Ctx implements Context {
           this.addApp(
             fromAccountAddr, flags,
             txnParam.approvalProgram,
-            txnParam.approvalProgram
+            txnParam.approvalProgram,
+            idx
           );
           break;
         }
         case types.TransactionType.OptInToApp: {
           this.tx = this.gtxs[idx]; // update current tx to txn being exectuted in group
 
-          this.optInToApp(fromAccountAddr, txnParam.appID);
+          this.optInToApp(fromAccountAddr, txnParam.appID, idx);
           break;
         }
       }

--- a/packages/runtime/src/ctx.ts
+++ b/packages/runtime/src/ctx.ts
@@ -221,13 +221,14 @@ export class Ctx implements Context {
    * @param payFlags Transaction parameters
    * @param approvalProgram application approval program
    * @param clearProgram application clear program
+   * @param idx index of transaction in group
    * NOTE:
    * - approval and clear program must be the TEAL code as string (not compiled code)
    * - When creating or opting into an app, the minimum balance grows before the app code runs
    */
   addApp (
     fromAccountAddr: AccountAddress, flags: AppDeploymentFlags,
-    approvalProgram: string, clearProgram: string, idx?: number
+    approvalProgram: string, clearProgram: string, idx: number
   ): number {
     const senderAcc = this.getAccount(fromAccountAddr);
 
@@ -245,7 +246,7 @@ export class Ctx implements Context {
     this.state.globalApps.set(app.id, senderAcc.address);
 
     this.runtime.run(
-      approvalProgram, ExecutionMode.APPLICATION, idx ?? 0, this.debugStack
+      approvalProgram, ExecutionMode.APPLICATION, idx, this.debugStack
     ); // execute TEAL code with appID = 0
 
     // create new application in globalApps map
@@ -274,15 +275,16 @@ export class Ctx implements Context {
    * Account address opt-in for application Id
    * @param accountAddr Account address to opt into application
    * @param appID Application index
+   * @param idx index of transaction in group
    * NOTE: When creating or opting into an app, the minimum balance grows before the app code runs
    */
-  optInToApp (accountAddr: AccountAddress, appID: number, idx?: number): void {
+  optInToApp (accountAddr: AccountAddress, appID: number, idx: number): void {
     const appParams = this.getApp(appID);
 
     const account = this.getAccount(accountAddr);
     account.optInToApp(appID, appParams);
     this.assertAccBalAboveMin(accountAddr);
-    this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, idx ?? 0, this.debugStack);
+    this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, idx, this.debugStack);
   }
 
   /**
@@ -479,7 +481,7 @@ export class Ctx implements Context {
     appID: number,
     approvalProgram: string,
     clearProgram: string,
-    idx?: number
+    idx: number
   ): void {
     if (approvalProgram === "") {
       throw new RuntimeError(RUNTIME_ERRORS.GENERAL.INVALID_APPROVAL_PROGRAM);
@@ -489,7 +491,7 @@ export class Ctx implements Context {
     }
 
     const appParams = this.getApp(appID);
-    this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, idx ?? 0, this.debugStack);
+    this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, idx, this.debugStack);
 
     const updatedApp = this.getApp(appID);
     updatedApp[APPROVAL_PROGRAM] = approvalProgram;

--- a/packages/runtime/src/ctx.ts
+++ b/packages/runtime/src/ctx.ts
@@ -24,7 +24,7 @@ export class Ctx implements Context {
   args: Uint8Array[];
   runtime: Runtime;
   debugStack?: number; //  max number of top elements from the stack to print after each opcode execution.
-  sharedScratchSpace: Map<number, StackElem[]>;
+  sharedScratchSpace: Map<number, StackElem[]>; // here number is index of transaction in a group
 
   constructor (state: State, tx: Txn, gtxs: Txn[], args: Uint8Array[],
     runtime: Runtime, debugStack?: number) {

--- a/packages/runtime/src/errors/errors-list.ts
+++ b/packages/runtime/src/errors/errors-list.ts
@@ -237,6 +237,12 @@ by an index that does not exist.`
     message: "set bit index %index% is beyond bytes length. [error-line: %line%]",
     title: 'set bit index error',
     description: `set bit index error`
+  },
+  SCRATCH_EXIST_ERROR: {
+    number: 1035,
+    message: "scratch space doesn't exist for index: %index%. [error-line: %line%]",
+    title: 'scratch space error',
+    description: `fails maybe because the requested transaction is an ApplicationCall or T < GroupIndex.`
   }
 };
 

--- a/packages/runtime/src/interpreter/opcode-list.ts
+++ b/packages/runtime/src/interpreter/opcode-list.ts
@@ -2591,3 +2591,84 @@ export class MinBalance extends Op {
     stack.push(BigInt(acc.minBalance));
   }
 }
+
+// push Ith scratch space index of the Tth transaction in the current group
+// push to stack [...stack, bigint/bytes]
+// Pops nothing
+// Args expected: [{uint8 transaction group index}(T),
+// {uint8 position in scratch space to load from}(I)]
+export class Gload extends Op {
+  readonly scratchIndex: number;
+  readonly txIndex: number;
+  readonly interpreter: Interpreter;
+  readonly line: number;
+
+  /**
+   * Stores scratch space index and transaction index number according to arguments passed.
+   * @param args Expected arguments: [index number]
+   * @param line line number in TEAL file
+   * @param interpreter interpreter object
+   */
+  constructor (args: string[], line: number, interpreter: Interpreter) {
+    super();
+    this.line = line;
+    assertLen(args.length, 2, this.line);
+    assertOnlyDigits(args[0], this.line);
+    assertOnlyDigits(args[1], this.line);
+
+    this.txIndex = Number(args[0]);
+    this.scratchIndex = Number(args[1]);
+    this.interpreter = interpreter;
+  }
+
+  execute (stack: TEALStack): void {
+    const scratch = this.interpreter.runtime.ctx.sharedScratchSpace.get(this.txIndex);
+    if (scratch === undefined) {
+      throw new RuntimeError(
+        RUNTIME_ERRORS.TEAL.SCRATCH_EXIST_ERROR,
+        { index: this.txIndex, line: this.line }
+      );
+    }
+    this.checkIndexBound(this.scratchIndex, scratch, this.line);
+    stack.push(scratch[this.scratchIndex]);
+  }
+}
+
+// push Ith scratch space index of the Tth transaction in the current group
+// push to stack [...stack, bigint/bytes]
+// Pops uint64(T)
+// Args expected: [{uint8 position in scratch space to load from}(I)]
+export class Gloads extends Op {
+  readonly scratchIndex: number;
+  readonly interpreter: Interpreter;
+  readonly line: number;
+
+  /**
+   * Stores scratch space index number according to argument passed.
+   * @param args Expected arguments: [index number]
+   * @param line line number in TEAL file
+   * @param interpreter interpreter object
+   */
+  constructor (args: string[], line: number, interpreter: Interpreter) {
+    super();
+    this.line = line;
+    assertLen(args.length, 1, this.line);
+    assertOnlyDigits(args[0], this.line);
+
+    this.scratchIndex = Number(args[0]);
+    this.interpreter = interpreter;
+  }
+
+  execute (stack: TEALStack): void {
+    const txIndex = Number(this.assertBigInt(stack.pop(), this.line));
+    const scratch = this.interpreter.runtime.ctx.sharedScratchSpace.get(txIndex);
+    if (scratch === undefined) {
+      throw new RuntimeError(
+        RUNTIME_ERRORS.TEAL.SCRATCH_EXIST_ERROR,
+        { index: txIndex, line: this.line }
+      );
+    }
+    this.checkIndexBound(this.scratchIndex, scratch, this.line);
+    stack.push(scratch[this.scratchIndex]);
+  }
+}

--- a/packages/runtime/src/lib/constants.ts
+++ b/packages/runtime/src/lib/constants.ts
@@ -10,7 +10,7 @@ export const MAX_CONCAT_SIZE = 4096;
 export const ALGORAND_MIN_TX_FEE = 1000;
 // https://github.com/algorand/go-algorand/blob/master/config/consensus.go#L659
 export const ALGORAND_ACCOUNT_MIN_BALANCE = 0.1e6; // 0.1 ALGO
-export const MaxTEALVersion = 3;
+export const MaxTEALVersion = 4;
 
 // values taken from: https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract
 // minimum balance costs (in microalgos) for ssc schema
@@ -109,12 +109,17 @@ TxnFields[3] = {
   LocalNumByteSlice: 'nbs'
 };
 
+TxnFields[4] = {
+  ...TxnFields[3]
+};
+
 // transaction fields of type array
 export const TxArrFields: {[key: number]: Set<string>} = {
   1: new Set(),
   2: new Set(['Accounts', 'ApplicationArgs'])
 };
 TxArrFields[3] = new Set([...TxArrFields[2], 'Assets', 'Applications']);
+TxArrFields[4] = TxArrFields[3];
 
 export const TxFieldDefaults: {[key: string]: any} = {
   Sender: zeroAddress,
@@ -235,6 +240,12 @@ GlobalFields[3] = {
   CreatorAddress: null
 };
 
+// global fields supported by tealv3
+GlobalFields[4] = {
+  ...GlobalFields[3],
+  CreatorAddress: null
+};
+
 // creating map for opcodes whose cost is other than 1
 export const OpGasCost: {[key: number]: {[key: string]: number}} = { // version => opcode => cost
   // v1 opcodes cost
@@ -259,3 +270,9 @@ OpGasCost[2] = {
  * All other opcodes have cost 1
  */
 OpGasCost[3] = { ...OpGasCost[2] };
+
+/**
+ * In tealv4, cost of crypto opcodes are same as v2.
+ * All other opcodes have cost 1
+ */
+OpGasCost[4] = { ...OpGasCost[3] };

--- a/packages/runtime/src/parser/parser.ts
+++ b/packages/runtime/src/parser/parser.ts
@@ -7,7 +7,7 @@ import {
   AppOptedIn, Arg, Assert, Balance, BitwiseAnd, BitwiseNot, BitwiseOr,
   BitwiseXor, Branch, BranchIfNotZero, BranchIfZero, Btoi,
   Byte, Bytec, Bytecblock, Concat, Dig, Div, Dup, Dup2, Ed25519verify,
-  EqualTo, Err, GetAssetDef, GetAssetHolding, GetBit, GetByte, Global, GreaterThan,
+  EqualTo, Err, GetAssetDef, GetAssetHolding, GetBit, GetByte, Gload, Gloads, Global, GreaterThan,
   GreaterThanEqualTo, Gtxn, Gtxna, Gtxns, Gtxnsa, Int, Intc, Intcblock, Itob,
   Keccak256, Label, Len, LessThan, LessThanEqualTo, Load, MinBalance, Mod,
   Mul, Mulw, Not, NotEqualTo, Or, Pop, Pragma, PushBytes, PushInt, Return, Select, SetBit, SetByte, Sha256,
@@ -150,6 +150,16 @@ opCodeMap[3] = {
   min_balance: MinBalance
 };
 
+/**
+ * TEALv4 opcodes: https://developer.algorand.org/articles/introducing-algorand-virtual-machine-avm-09-release/
+ */
+opCodeMap[4] = {
+  ...opCodeMap[3],
+
+  gload: Gload,
+  gloads: Gloads
+};
+
 // list of opcodes that require one extra parameter than others: `interpreter`.
 const interpreterReqList = new Set([
   "#pragma", "arg", "bytecblock", "bytec", "intcblock", "intc", "store",
@@ -157,7 +167,7 @@ const interpreterReqList = new Set([
   "balance", "asset_holding_get", "asset_params_get", "app_opted_in",
   "app_local_get", "app_local_get_ex", "app_global_get", "app_global_get_ex",
   "app_local_put", "app_global_put", "app_local_del", "app_global_del",
-  "gtxns", "gtxnsa", "min_balance"
+  "gtxns", "gtxnsa", "min_balance", "gload", "gloads"
 ]);
 
 /**

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -594,7 +594,7 @@ export class Runtime {
       if (program === "") {
         throw new RuntimeError(RUNTIME_ERRORS.GENERAL.INVALID_PROGRAM);
       }
-      this.run(program, ExecutionMode.SIGNATURE, debugStack);
+      this.run(program, ExecutionMode.SIGNATURE, 0, debugStack);
     } else {
       throw new RuntimeError(RUNTIME_ERRORS.GENERAL.LOGIC_SIGNATURE_NOT_FOUND);
     }
@@ -627,6 +627,7 @@ export class Runtime {
     this.validateTxRound(gtxs);
 
     // initialize context before each execution
+    // Prepare shared space at each execution of transaction/s.
     // state is a deep copy of store
     this.ctx = new Ctx(cloneDeep(this.store), tx, gtxs, [], this, debugStack);
 
@@ -646,8 +647,11 @@ export class Runtime {
    * each opcode execution (upto depth = debugStack)
    * NOTE: Application mode is only supported in TEALv > 1
    */
-  run (program: string, executionMode: ExecutionMode, debugStack?: number): void {
+  run (program: string, executionMode: ExecutionMode, indexInGroup: number, debugStack?: number): void {
     const interpreter = new Interpreter();
     interpreter.execute(program, executionMode, this, debugStack);
+    if (executionMode === ExecutionMode.APPLICATION) {
+      this.ctx.sharedScratchSpace.set(indexInGroup, interpreter.scratch);
+    }
   }
 }

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -443,7 +443,7 @@ export class Runtime {
   ): number {
     this.addCtxAppCreateTxn(flags, payFlags);
     this.ctx.debugStack = debugStack;
-    this.ctx.addApp(flags.sender.addr, flags, approvalProgram, clearProgram);
+    this.ctx.addApp(flags.sender.addr, flags, approvalProgram, clearProgram, 0);
 
     this.store = this.ctx.state;
     return this.store.appCounter;
@@ -485,7 +485,7 @@ export class Runtime {
     flags: AppOptionalFlags, payFlags: types.TxParams, debugStack?: number): void {
     this.addCtxOptInTx(accountAddr, appID, payFlags, flags);
     this.ctx.debugStack = debugStack;
-    this.ctx.optInToApp(accountAddr, appID);
+    this.ctx.optInToApp(accountAddr, appID, 0);
 
     this.store = this.ctx.state;
   }
@@ -538,7 +538,7 @@ export class Runtime {
   ): void {
     this.addCtxAppUpdateTx(senderAddr, appID, payFlags, flags);
     this.ctx.debugStack = debugStack;
-    this.ctx.updateApp(appID, approvalProgram, clearProgram);
+    this.ctx.updateApp(appID, approvalProgram, clearProgram, 0);
 
     // If successful, Update programs and state
     this.store = this.ctx.state;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -100,6 +100,7 @@ export interface SSCInfo extends DeployedAssetInfo {
 // describes interpreter's local context (state + txns)
 export interface Context {
   state: State
+  sharedScratchSpace: Map<number, StackElem[]>
   tx: Txn // current txn
   gtxs: Txn[] // all transactions
   args?: Uint8Array[]

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -128,13 +128,14 @@ export interface Context {
     name: string, asaDef: types.ASADef,
     fromAccountAddr: AccountAddress, flags: ASADeploymentFlags
   ) => number
-  optIntoASA: (assetIndex: number, address: AccountAddress, flags: types.TxParams) => void
+  optIntoASA: (
+    assetIndex: number, address: AccountAddress, flags: types.TxParams) => void
   addApp: (
     fromAccountAddr: string, flags: AppDeploymentFlags,
-    approvalProgram: string, clearProgram: string
+    approvalProgram: string, clearProgram: string, idx: number
   ) => number
-  optInToApp: (accountAddr: string, appID: number) => void
-  updateApp: (appID: number, approvalProgram: string, clearProgram: string) => void
+  optInToApp: (accountAddr: string, appID: number, idx: number) => void
+  updateApp: (appID: number, approvalProgram: string, clearProgram: string, idx: number) => void
 }
 
 // custom AssetHolding for AccountStore (using bigint in amount instead of number)

--- a/packages/runtime/test/src/interpreter/opcode-list.ts
+++ b/packages/runtime/test/src/interpreter/opcode-list.ts
@@ -14,7 +14,7 @@ import {
   AppOptedIn, Arg, Assert, Balance, BitwiseAnd, BitwiseNot, BitwiseOr,
   BitwiseXor, Branch, BranchIfNotZero, BranchIfZero, Btoi,
   Byte, Bytec, Bytecblock, Concat, Dig, Div, Dup, Dup2, Ed25519verify,
-  EqualTo, Err, GetAssetDef, GetAssetHolding, GetBit, GetByte, Global,
+  EqualTo, Err, GetAssetDef, GetAssetHolding, GetBit, GetByte, Gload, Global,
   GreaterThan, GreaterThanEqualTo, Gtxn, Gtxna, Gtxns, Gtxnsa, Int, Intc,
   Intcblock, Itob, Keccak256, Label, Len, LessThan, LessThanEqualTo,
   Load, MinBalance, Mod, Mul, Mulw, Not, NotEqualTo, Or, Pragma, PushBytes, PushInt, Return,
@@ -4067,6 +4067,57 @@ describe("Teal Opcodes", function () {
     it("should throw index out of bound error", () => {
       const op = new Balance([], 1, interpreter);
       stack.push(8n);
+
+      expectRuntimeError(
+        () => op.execute(stack),
+        RUNTIME_ERRORS.TEAL.INDEX_OUT_OF_BOUND
+      );
+    });
+  });
+
+  describe("shared data between contracts", () => {
+    let stack: Stack<StackElem>;
+    let interpreter: Interpreter;
+
+    this.beforeAll(() => {
+      interpreter = new Interpreter();
+      interpreter.runtime = new Runtime([]);
+      interpreter.tealVersion = MaxTEALVersion;
+      interpreter.runtime.ctx.tx = TXN_OBJ;
+      interpreter.runtime.ctx.sharedScratchSpace = new Map<number, StackElem[]>();
+      interpreter.runtime.ctx.sharedScratchSpace.set(0, [12n, 2n, 0n]);
+      interpreter.runtime.ctx.sharedScratchSpace.set(2, [12n, 2n, 0n, 1n]);
+    });
+
+    this.beforeEach(() => { stack = new Stack<StackElem>(); });
+
+    it("should push value from ith tx in shared scratch space", () => {
+      const op = new Gload(["0", "1"], 1, interpreter);
+
+      op.execute(stack);
+      const top = stack.pop();
+
+      assert.equal(top, 2n);
+    });
+
+    it("should throw error if tx doesn't exist", () => {
+      let op = new Gload(["1", "1"], 1, interpreter);
+
+      expectRuntimeError(
+        () => op.execute(stack),
+        RUNTIME_ERRORS.TEAL.SCRATCH_EXIST_ERROR
+      );
+
+      op = new Gload(["1", "3"], 1, interpreter);
+
+      expectRuntimeError(
+        () => op.execute(stack),
+        RUNTIME_ERRORS.TEAL.SCRATCH_EXIST_ERROR
+      );
+    });
+
+    it("should throw error if value doesn't exist in stack elem array", () => {
+      const op = new Gload(["2", "5"], 1, interpreter);
 
       expectRuntimeError(
         () => op.execute(stack),

--- a/packages/runtime/test/src/interpreter/opcode-list.ts
+++ b/packages/runtime/test/src/interpreter/opcode-list.ts
@@ -14,7 +14,7 @@ import {
   AppOptedIn, Arg, Assert, Balance, BitwiseAnd, BitwiseNot, BitwiseOr,
   BitwiseXor, Branch, BranchIfNotZero, BranchIfZero, Btoi,
   Byte, Bytec, Bytecblock, Concat, Dig, Div, Dup, Dup2, Ed25519verify,
-  EqualTo, Err, GetAssetDef, GetAssetHolding, GetBit, GetByte, Gload, Global,
+  EqualTo, Err, GetAssetDef, GetAssetHolding, GetBit, GetByte, Gload, Gloads, Global,
   GreaterThan, GreaterThanEqualTo, Gtxn, Gtxna, Gtxns, Gtxnsa, Int, Intc,
   Intcblock, Itob, Keccak256, Label, Len, LessThan, LessThanEqualTo,
   Load, MinBalance, Mod, Mul, Mulw, Not, NotEqualTo, Or, Pragma, PushBytes, PushInt, Return,
@@ -4091,7 +4091,7 @@ describe("Teal Opcodes", function () {
 
     this.beforeEach(() => { stack = new Stack<StackElem>(); });
 
-    it("should push value from ith tx in shared scratch space", () => {
+    it("should push value from ith tx in shared scratch space(gload)", () => {
       const op = new Gload(["0", "1"], 1, interpreter);
 
       op.execute(stack);
@@ -4100,7 +4100,7 @@ describe("Teal Opcodes", function () {
       assert.equal(top, 2n);
     });
 
-    it("should throw error if tx doesn't exist", () => {
+    it("should throw error if tx doesn't exist(gload)", () => {
       let op = new Gload(["1", "1"], 1, interpreter);
 
       expectRuntimeError(
@@ -4116,8 +4116,46 @@ describe("Teal Opcodes", function () {
       );
     });
 
-    it("should throw error if value doesn't exist in stack elem array", () => {
+    it("should throw error if value doesn't exist in stack elem array(gload)", () => {
       const op = new Gload(["2", "5"], 1, interpreter);
+
+      expectRuntimeError(
+        () => op.execute(stack),
+        RUNTIME_ERRORS.TEAL.INDEX_OUT_OF_BOUND
+      );
+    });
+
+    it("should push value from ith tx in shared scratch space(gloads)", () => {
+      const op = new Gloads(["1"], 1, interpreter);
+      stack.push(0n);
+
+      op.execute(stack);
+      const top = stack.pop();
+
+      assert.equal(top, 2n);
+    });
+
+    it("should throw error if tx doesn't exist(gloads)", () => {
+      let op = new Gloads(["1"], 1, interpreter);
+      stack.push(1n);
+
+      expectRuntimeError(
+        () => op.execute(stack),
+        RUNTIME_ERRORS.TEAL.SCRATCH_EXIST_ERROR
+      );
+
+      op = new Gloads(["3"], 1, interpreter);
+      stack.push(1n);
+
+      expectRuntimeError(
+        () => op.execute(stack),
+        RUNTIME_ERRORS.TEAL.SCRATCH_EXIST_ERROR
+      );
+    });
+
+    it("should throw error if value doesn't exist in stack elem array(gloads)", () => {
+      const op = new Gloads(["5"], 1, interpreter);
+      stack.push(2n);
 
       expectRuntimeError(
         () => op.execute(stack),

--- a/packages/runtime/test/src/parser/parser.ts
+++ b/packages/runtime/test/src/parser/parser.ts
@@ -8,13 +8,11 @@ import {
   AppOptedIn, Arg, Assert, Balance, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor,
   Branch, BranchIfNotZero, BranchIfZero, Btoi, Byte, Bytec, Concat, Dig, Div,
   Dup, Dup2, Ed25519verify, EqualTo, Err, GetAssetDef, GetAssetHolding,
-  GetBit,
-  GetByte,
-  Global, GreaterThan, GreaterThanEqualTo, Gtxn, Gtxna, Gtxns, Gtxnsa, Int, Intc, Itob,
-  Keccak256, Label, Len, LessThan, LessThanEqualTo, Load, MinBalance, Mod, Mul, Mulw,
-  Not, NotEqualTo, Or, Pop, Pragma, PushBytes, PushInt, Return, Select, SetBit,
-  SetByte, Sha256, Sha512_256, Store,
-  Sub, Substring, Substring3, Swap, Txn, Txna
+  GetBit, GetByte, Gload, Gloads, Global, GreaterThan, GreaterThanEqualTo, Gtxn, Gtxna,
+  Gtxns, Gtxnsa, Int, Intc, Itob, Keccak256, Label, Len, LessThan,
+  LessThanEqualTo, Load, MinBalance, Mod, Mul, Mulw, Not, NotEqualTo,
+  Or, Pop, Pragma, PushBytes, PushInt, Return, Select, SetBit, SetByte,
+  Sha256, Sha512_256, Store, Sub, Substring, Substring3, Swap, Txn, Txna
 } from "../../../src/interpreter/opcode-list";
 import { MAX_UINT64, MaxTEALVersion, MIN_UINT64 } from "../../../src/lib/constants";
 import { opcodeFromSentence, parser, wordsFromLine } from "../../../src/parser/parser";
@@ -884,6 +882,40 @@ describe("Parser", function () {
 
         expectRuntimeError(
           () => opcodeFromSentence(["min_balance", "xyz"], 1, interpreter),
+          RUNTIME_ERRORS.TEAL.ASSERT_LENGTH
+        );
+      });
+    });
+
+    describe("should return correct opcodes for tealv4 ops", () => {
+      it("gload", () => {
+        const res = opcodeFromSentence(["gload", "0", "1"], 1, interpreter);
+        const expected = new Gload(["0", "1"], 1, interpreter);
+        assert.deepEqual(res, expected);
+
+        expectRuntimeError(
+          () => opcodeFromSentence(["gload", "one", "1"], 1, interpreter),
+          RUNTIME_ERRORS.TEAL.INVALID_TYPE
+        );
+
+        expectRuntimeError(
+          () => opcodeFromSentence(["gload", "0"], 1, interpreter),
+          RUNTIME_ERRORS.TEAL.ASSERT_LENGTH
+        );
+      });
+
+      it("gloads", () => {
+        const res = opcodeFromSentence(["gloads", "0"], 1, interpreter);
+        const expected = new Gloads(["0"], 1, interpreter);
+        assert.deepEqual(res, expected);
+
+        expectRuntimeError(
+          () => opcodeFromSentence(["gloads", "one"], 1, interpreter),
+          RUNTIME_ERRORS.TEAL.INVALID_TYPE
+        );
+
+        expectRuntimeError(
+          () => opcodeFromSentence(["gloads", "0", "1"], 1, interpreter),
           RUNTIME_ERRORS.TEAL.ASSERT_LENGTH
         );
       });


### PR DESCRIPTION
## Proposed Changes

+ Add shared scratch space support in runtime
+ Add tealv4 constants
+ Add `gload` and `gloads` opcodes
+ Add tests

## Potential followups
+ Add integration test with two stateful contracts (https://www.pivotaltracker.com/story/show/179202771)