### PR TITLE
Tealv4 byteslice arithmatic: implement b+ opcode

### DIFF
--- a/packages/runtime/src/errors/errors-list.ts
+++ b/packages/runtime/src/errors/errors-list.ts
@@ -243,6 +243,12 @@ by an index that does not exist.`
     message: "scratch space doesn't exist for index: %index%. [error-line: %line%], fails maybe because the requested transaction is an ApplicationCall or T < GroupIndex.",
     title: 'scratch space not found',
     description: `fails maybe because the requested transaction is an ApplicationCall or T < GroupIndex.`
+  },
+  BYTES_LEN_EXCEEDED: {
+    number: 1036,
+    message: "Byteslice Arithmetic Error: length of input/output bytes(= %len%) exceed max length of %expected%. [error-line: %line%]",
+    title: 'Byteslice Arithmetic Error',
+    description: `length of input/output bytes exceed max length`
   }
 };
 

--- a/packages/runtime/src/interpreter/opcode-list.ts
+++ b/packages/runtime/src/interpreter/opcode-list.ts
@@ -9,9 +9,12 @@ import { Keccak } from 'sha3';
 import { RUNTIME_ERRORS } from "../errors/errors-list";
 import { RuntimeError } from "../errors/runtime-errors";
 import { compareArray } from "../lib/compare";
-import { AssetParamMap, GlobalFields, MAX_CONCAT_SIZE, MAX_UINT64, MaxTEALVersion, TxArrFields } from "../lib/constants";
 import {
-  assertLen, assertOnlyDigits, convertToBuffer,
+  AssetParamMap, GlobalFields, MAX_CONCAT_SIZE, MAX_INPUT_BYTE_LEN, MAX_OUTPUT_BYTE_LEN,
+  MAX_UINT64, MaxTEALVersion, TxArrFields
+} from "../lib/constants";
+import {
+  assertLen, assertOnlyDigits, bigEndianBytesToBigInt, bigintToBigEndianBytes, convertToBuffer,
   convertToString, getEncoding, parseBinaryStrToBigInt
 } from "../lib/parsing";
 import { Stack } from "../lib/stack";
@@ -2592,6 +2595,8 @@ export class MinBalance extends Op {
   }
 }
 
+/** TEALv4 Ops **/
+
 // push Ith scratch space index of the Tth transaction in the current group
 // push to stack [...stack, bigint/bytes]
 // Pops nothing
@@ -2651,7 +2656,36 @@ export class Gloads extends Gload {
   }
 
   execute (stack: TEALStack): void {
+    this.assertMinStackLen(stack, 1, this.line);
     this.txIndex = Number(this.assertBigInt(stack.pop(), this.line));
     super.execute(stack);
+  }
+}
+
+// A plus B, where A and B are byte-arrays interpreted as big-endian unsigned integers
+// panics on overflow (result > max_uint1024 i.e 128 byte num)
+// Pops: ... stack, {[]byte A}, {[]byte B}
+// push to stack [...stack, []byte]
+export class ByteAdd extends Op {
+  readonly line: number;
+  /**
+   * Asserts 0 arguments are passed.
+   * @param args Expected arguments: [] // none
+   * @param line line number in TEAL file
+   */
+  constructor (args: string[], line: number) {
+    super();
+    this.line = line;
+    assertLen(args.length, 0, line);
+  };
+
+  execute (stack: TEALStack): void {
+    this.assertMinStackLen(stack, 2, this.line);
+    const byteB = this.assertBytes(stack.pop(), this.line, MAX_INPUT_BYTE_LEN);
+    const byteA = this.assertBytes(stack.pop(), this.line, MAX_INPUT_BYTE_LEN);
+
+    const result = bigEndianBytesToBigInt(byteA) + bigEndianBytesToBigInt(byteB);
+    const resultAsBytes = bigintToBigEndianBytes(result);
+    stack.push(this.assertBytes(resultAsBytes, this.line, MAX_OUTPUT_BYTE_LEN));
   }
 }

--- a/packages/runtime/src/interpreter/opcode.ts
+++ b/packages/runtime/src/interpreter/opcode.ts
@@ -82,12 +82,20 @@ export class Op {
    * asserts if given variable type is bytes
    * @param b variable
    * @param line line number in TEAL file
+   * @param maxlen maximum allowed length of bytes
    */
-  assertBytes (b: unknown, line: number): Uint8Array {
+  assertBytes (b: unknown, line: number, maxlen?: number): Uint8Array {
     if (typeof b === 'undefined' || !(b instanceof Uint8Array)) {
       throw new RuntimeError(RUNTIME_ERRORS.TEAL.INVALID_TYPE, {
         expected: "byte[]",
         actual: typeof b,
+        line: line
+      });
+    }
+    if (maxlen !== undefined && b.length > maxlen) {
+      throw new RuntimeError(RUNTIME_ERRORS.TEAL.BYTES_LEN_EXCEEDED, {
+        len: b.length,
+        expected: maxlen,
         line: line
       });
     }

--- a/packages/runtime/src/lib/constants.ts
+++ b/packages/runtime/src/lib/constants.ts
@@ -29,6 +29,11 @@ export const MaxAppProgramLen = 1024;
 export const MAX_ALGORAND_ACCOUNT_ASSETS = 1000;
 export const MAX_ALGORAND_ACCOUNT_APPS = 10;
 
+// for byteslice arithmetic ops, inputs are limited to 64 bytes,
+// but ouput can be upto 128 bytes (eg. when using b+ OR b*)
+export const MAX_INPUT_BYTE_LEN = 64;
+export const MAX_OUTPUT_BYTE_LEN = 128;
+
 const zeroAddress = new Uint8Array(32);
 const zeroUint64 = 0n;
 const zeroByte = new Uint8Array(0);

--- a/packages/runtime/src/lib/parsing.ts
+++ b/packages/runtime/src/lib/parsing.ts
@@ -171,3 +171,54 @@ export function parseBinaryStrToBigInt (binary: string[] | string): bigint {
   }
   return res;
 }
+
+/**
+ * Parses bigint to big endian bytes (represeted as Uint8array)
+ * NOTE: This is different from decodeUint64, encodeUint64 as it is capable of
+ * handling bigint > 64 bit (8 bytes).
+ * @param b value in bigint to parse
+ */
+export function bigintToBigEndianBytes (b: bigint): Uint8Array {
+  // `toString(base)` works
+  let hex = BigInt(b).toString(16);
+
+  // But it still follows the old behavior of giving
+  // invalid hex strings (due to missing padding),
+  // but we can easily add that back
+  if (hex.length % 2) { hex = '0' + hex; }
+
+  // The byteLength will be half of the hex string length
+  const len = hex.length / 2;
+  const u8 = new Uint8Array(len);
+
+  // And then we can iterate each element by one
+  // and each hex segment by two
+  let i = 0;
+  let j = 0;
+  while (i < len) {
+    u8[i] = parseInt(hex.slice(j, j + 2), 16);
+    i += 1;
+    j += 2;
+  }
+
+  return u8;
+}
+
+/**
+ * Parses unsigned big endian bytes (represented as Uint8array) back to bigint
+ * NOTE: This is different from decodeUint64, encodeUint64 as it is capable of
+ * handling bigint > 64 bit (8 bytes).
+ * @param bytes big endian bytes (buffer or Uint8array)
+ */
+export function bigEndianBytesToBigInt (bytes: Uint8Array | Buffer): bigint {
+  const hex: string[] = [];
+  const u8 = Uint8Array.from(bytes);
+
+  u8.forEach(function (i) {
+    let h = i.toString(16);
+    if (h.length % 2) { h = '0' + h; }
+    hex.push(h);
+  });
+
+  return BigInt('0x' + hex.join(''));
+}

--- a/packages/runtime/src/parser/parser.ts
+++ b/packages/runtime/src/parser/parser.ts
@@ -6,7 +6,7 @@ import {
   AppGlobalPut, AppLocalDel, AppLocalGet, AppLocalGetEx, AppLocalPut,
   AppOptedIn, Arg, Assert, Balance, BitwiseAnd, BitwiseNot, BitwiseOr,
   BitwiseXor, Branch, BranchIfNotZero, BranchIfZero, Btoi,
-  Byte, Bytec, Bytecblock, Concat, Dig, Div, Dup, Dup2, Ed25519verify,
+  Byte, ByteAdd, Bytec, Bytecblock, Concat, Dig, Div, Dup, Dup2, Ed25519verify,
   EqualTo, Err, GetAssetDef, GetAssetHolding, GetBit, GetByte, Gload, Gloads, Global, GreaterThan,
   GreaterThanEqualTo, Gtxn, Gtxna, Gtxns, Gtxnsa, Int, Intc, Intcblock, Itob,
   Keccak256, Label, Len, LessThan, LessThanEqualTo, Load, MinBalance, Mod,
@@ -157,7 +157,10 @@ opCodeMap[4] = {
   ...opCodeMap[3],
 
   gload: Gload,
-  gloads: Gloads
+  gloads: Gloads,
+
+  // byteslice arithmetic ops
+  'b+': ByteAdd
 };
 
 // list of opcodes that require one extra parameter than others: `interpreter`.

--- a/packages/runtime/test/src/lib/parsing.ts
+++ b/packages/runtime/test/src/lib/parsing.ts
@@ -3,7 +3,7 @@ import { decodeAddress } from "algosdk";
 import { assert } from "chai";
 
 import { MAX_UINT64, MIN_UINT64 } from "../../../src/lib/constants";
-import { convertToString } from "../../../src/lib/parsing";
+import { bigEndianBytesToBigInt, bigintToBigEndianBytes, convertToString } from "../../../src/lib/parsing";
 
 describe("Convert integer to big endian", () => {
   /**
@@ -53,6 +53,63 @@ describe("Convert integer to big endian", () => {
 
     res = parsing.uint64ToBigEndian(MAX_UINT64);
     expected = new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255]);
+    assert.deepEqual(res, expected);
+  });
+
+  /* eslint-disable max-len */
+  it("should return correct big endian bytes from bigint", () => {
+    let res = bigintToBigEndianBytes(MIN_UINT64);
+    let expected = new Uint8Array([0]); // this is not "strict" uintN byte conversion, so 0 is parsed as new Uint8array([0])
+    assert.deepEqual(res, expected);
+
+    res = bigintToBigEndianBytes(MAX_UINT64); // max 8 bytes array
+    expected = new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255]);
+    assert.deepEqual(res, expected);
+
+    // max 16 bytes array
+    res = bigintToBigEndianBytes(340282366920938463463374607431768211455n);
+    expected = new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]);
+    assert.deepEqual(res, expected);
+
+    // max 32 bytes array (i.e 256 bit unsigned integer)
+    res = bigintToBigEndianBytes(115792089237316195423570985008687907853269984665640564039457584007913129639935n);
+    expected = new Uint8Array(32).fill(255);
+    assert.deepEqual(res, expected);
+
+    // max 64 bytes array (i.e 512 bit unsigned integer)
+    res = bigintToBigEndianBytes(13407807929942597099574024998205846127479365820592393377723561443721764030073546976801874298166903427690031858186486050853753882811946569946433649006084095n);
+    expected = new Uint8Array(64).fill(255);
+    assert.deepEqual(res, expected);
+
+    // max 128 bytes array (i.e 1024 bit unsigned integer)
+    res = bigintToBigEndianBytes(179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137215n);
+    expected = new Uint8Array(128).fill(255);
+    assert.deepEqual(res, expected);
+  });
+
+  it("should return correct bigint value from big endian bytes", () => {
+    let res = bigEndianBytesToBigInt(new Uint8Array([0]));
+    let expected = 0n;
+    assert.deepEqual(res, expected);
+
+    res = bigEndianBytesToBigInt(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0]));
+    expected = 0n;
+    assert.deepEqual(res, expected);
+
+    res = bigEndianBytesToBigInt(new Uint8Array(8).fill(255));
+    expected = MAX_UINT64;
+    assert.deepEqual(res, expected);
+
+    res = bigEndianBytesToBigInt(new Uint8Array(16).fill(255));
+    expected = 340282366920938463463374607431768211455n;
+    assert.deepEqual(res, expected);
+
+    res = bigEndianBytesToBigInt(new Uint8Array(32).fill(255));
+    expected = 115792089237316195423570985008687907853269984665640564039457584007913129639935n;
+    assert.deepEqual(res, expected);
+
+    res = bigEndianBytesToBigInt(new Uint8Array(64).fill(255));
+    expected = 13407807929942597099574024998205846127479365820592393377723561443721764030073546976801874298166903427690031858186486050853753882811946569946433649006084095n;
     assert.deepEqual(res, expected);
   });
 


### PR DESCRIPTION
Closes #x

## Proposed Changes

+ add parsing functions (`bigintToBigEndianBytes`, `bigEndianBytesToBigInt`) with tests
+ implement `b+` op
