### PR TITLE
Pass test filename to arguments of algob test command

### DIFF
--- a/packages/algob/src/builtin-tasks/deploy.ts
+++ b/packages/algob/src/builtin-tasks/deploy.ts
@@ -2,8 +2,9 @@ import { BuilderError, ERRORS } from "@algo-builder/web";
 import fs from "fs";
 
 import { task } from "../internal/core/config/config-env";
+import { loadFilenames } from "../internal/util/files";
 import { AlgoOperator, createAlgoOperator } from "../lib/algo-operator";
-import { assertDirectDirChildren, loadFilenames } from "../lib/files";
+import { assertDirectDirChildren } from "../lib/files";
 import {
   persistCheckpoint,
   scriptsDirectory,

--- a/packages/algob/src/builtin-tasks/deploy.ts
+++ b/packages/algob/src/builtin-tasks/deploy.ts
@@ -1,12 +1,9 @@
 import { BuilderError, ERRORS } from "@algo-builder/web";
 import fs from "fs";
-import glob from "glob";
-import path from "path";
 
 import { task } from "../internal/core/config/config-env";
 import { AlgoOperator, createAlgoOperator } from "../lib/algo-operator";
-import { cmpStr } from "../lib/comparators";
-import { assertDirectDirChildren } from "../lib/files";
+import { assertDirectDirChildren, loadFilenames } from "../lib/files";
 import {
   persistCheckpoint,
   scriptsDirectory,
@@ -19,30 +16,6 @@ import { TASK_DEPLOY } from "./task-names";
 export interface TaskArgs {
   fileNames: string[]
   force: boolean
-}
-
-/**
- * Load .js, .ts files from /scripts (default) directory
- * @param directory directory to load files from
- * @param taskType task type (eg. test)
- * @returns array of paths as string eg. ['scripts/file1.js', 'scripts/file2.js', ..]
- */
-export function loadFilenames (directory: string, taskType?: string): string[] {
-  if (!fs.existsSync(directory)) {
-    if (taskType === "test") {
-      throw new BuilderError(ERRORS.BUILTIN_TASKS.TESTS_DIRECTORY_NOT_FOUND, {
-        directory
-      });
-    } else {
-      throw new BuilderError(ERRORS.BUILTIN_TASKS.SCRIPTS_DIRECTORY_NOT_FOUND, {
-        directory
-      });
-    }
-  }
-
-  return glob.sync(path.join(directory, "*.js"))
-    .concat(glob.sync(path.join(directory, "*.ts")))
-    .sort(cmpStr);
 }
 
 function clearCheckpointFiles (scriptNames: string[]): void {

--- a/packages/algob/src/builtin-tasks/test.ts
+++ b/packages/algob/src/builtin-tasks/test.ts
@@ -2,9 +2,9 @@ import findupSync from "findup-sync";
 import Mocha from "mocha";
 
 import { task } from "../internal/core/config/config-env";
+import { loadFilenames } from "../lib/files";
 import { testsDirectory } from "../lib/script-checkpoints";
 import type { Config } from "../types";
-import { loadFilenames } from "./deploy";
 import { TASK_TEST } from "./task-names";
 
 const TEST_DIR = 'test';

--- a/packages/algob/src/builtin-tasks/test.ts
+++ b/packages/algob/src/builtin-tasks/test.ts
@@ -2,7 +2,7 @@ import findupSync from "findup-sync";
 import Mocha from "mocha";
 
 import { task } from "../internal/core/config/config-env";
-import { loadFilenames } from "../lib/files";
+import { loadFilenames } from "../internal/util/files";
 import { testsDirectory } from "../lib/script-checkpoints";
 import type { TaskTestConfig } from "../types";
 import { TASK_TEST } from "./task-names";

--- a/packages/algob/src/builtin-tasks/test.ts
+++ b/packages/algob/src/builtin-tasks/test.ts
@@ -17,7 +17,7 @@ async function runTests (config: TaskTestConfig): Promise<void> {
       require('ts-mocha');
     }
     // User pass testFiles to arguments so just run those files.
-    // else we run test files in default test dir.
+    // else we run test files in default(root) test dir.
     const testFiles = config.testFiles.length !== 0
       ? config.testFiles
       : loadFilenames(testsDirectory, TEST_DIR);
@@ -38,7 +38,7 @@ export default function (): void {
   task(TASK_TEST, "Run tests using mocha in project root")
     .addOptionalVariadicPositionalParam(
       "testFiles",
-      "An optional list of files to test",
+      "An optional list of file path(s) to test",
       []
     )
     .setAction((config) => runTests(config));

--- a/packages/algob/src/internal/util/files.ts
+++ b/packages/algob/src/internal/util/files.ts
@@ -1,0 +1,30 @@
+import { BuilderError, ERRORS, types } from "@algo-builder/web";
+import fs from "fs";
+import glob from "glob";
+import path from "path";
+
+import { cmpStr } from "../../lib/comparators";
+
+/**
+ * Load .js, .ts files from /scripts (default) directory
+ * @param directory directory to load files from
+ * @param taskType task type (eg. test)
+ * @returns array of paths as string eg. ['scripts/file1.js', 'scripts/file2.js', ..]
+ */
+export function loadFilenames (directory: string, taskType?: string): string[] {
+  if (!fs.existsSync(directory)) {
+    if (taskType === "test") {
+      throw new BuilderError(ERRORS.BUILTIN_TASKS.TESTS_DIRECTORY_NOT_FOUND, {
+        directory
+      });
+    } else {
+      throw new BuilderError(ERRORS.BUILTIN_TASKS.SCRIPTS_DIRECTORY_NOT_FOUND, {
+        directory
+      });
+    }
+  }
+
+  return glob.sync(path.join(directory, "*.js"))
+    .concat(glob.sync(path.join(directory, "*.ts")))
+    .sort(cmpStr);
+}

--- a/packages/algob/src/lib/files.ts
+++ b/packages/algob/src/lib/files.ts
@@ -1,11 +1,9 @@
 import { getPathFromDirRecursive } from "@algo-builder/runtime";
 import { BuilderError, ERRORS, types } from "@algo-builder/web";
 import fs from "fs-extra";
-import glob from "glob";
 import path from "path";
 
 import { ASSETS_DIR } from "../internal/core/project-structure";
-import { cmpStr } from "./comparators";
 
 function normalizePaths (mainPath: string, paths: string[]): string[] {
   return paths.map(n => path.relative(mainPath, n));
@@ -49,28 +47,4 @@ export function loadEncodedTxFromFile (fileName: string): Uint8Array | undefined
     if (types.isFileError(e) && e?.errno === -2) { return undefined; } // handling a not existing file
     throw e;
   }
-}
-
-/**
- * Load .js, .ts files from /scripts (default) directory
- * @param directory directory to load files from
- * @param taskType task type (eg. test)
- * @returns array of paths as string eg. ['scripts/file1.js', 'scripts/file2.js', ..]
- */
-export function loadFilenames (directory: string, taskType?: string): string[] {
-  if (!fs.existsSync(directory)) {
-    if (taskType === "test") {
-      throw new BuilderError(ERRORS.BUILTIN_TASKS.TESTS_DIRECTORY_NOT_FOUND, {
-        directory
-      });
-    } else {
-      throw new BuilderError(ERRORS.BUILTIN_TASKS.SCRIPTS_DIRECTORY_NOT_FOUND, {
-        directory
-      });
-    }
-  }
-
-  return glob.sync(path.join(directory, "*.js"))
-    .concat(glob.sync(path.join(directory, "*.ts")))
-    .sort(cmpStr);
 }

--- a/packages/algob/src/lib/files.ts
+++ b/packages/algob/src/lib/files.ts
@@ -1,9 +1,11 @@
 import { getPathFromDirRecursive } from "@algo-builder/runtime";
 import { BuilderError, ERRORS, types } from "@algo-builder/web";
 import fs from "fs-extra";
+import glob from "glob";
 import path from "path";
 
 import { ASSETS_DIR } from "../internal/core/project-structure";
+import { cmpStr } from "./comparators";
 
 function normalizePaths (mainPath: string, paths: string[]): string[] {
   return paths.map(n => path.relative(mainPath, n));
@@ -47,4 +49,28 @@ export function loadEncodedTxFromFile (fileName: string): Uint8Array | undefined
     if (types.isFileError(e) && e?.errno === -2) { return undefined; } // handling a not existing file
     throw e;
   }
+}
+
+/**
+ * Load .js, .ts files from /scripts (default) directory
+ * @param directory directory to load files from
+ * @param taskType task type (eg. test)
+ * @returns array of paths as string eg. ['scripts/file1.js', 'scripts/file2.js', ..]
+ */
+export function loadFilenames (directory: string, taskType?: string): string[] {
+  if (!fs.existsSync(directory)) {
+    if (taskType === "test") {
+      throw new BuilderError(ERRORS.BUILTIN_TASKS.TESTS_DIRECTORY_NOT_FOUND, {
+        directory
+      });
+    } else {
+      throw new BuilderError(ERRORS.BUILTIN_TASKS.SCRIPTS_DIRECTORY_NOT_FOUND, {
+        directory
+      });
+    }
+  }
+
+  return glob.sync(path.join(directory, "*.js"))
+    .concat(glob.sync(path.join(directory, "*.ts")))
+    .sort(cmpStr);
 }

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -134,6 +134,10 @@ export interface Config {
   mocha?: Mocha.MochaOptions
 }
 
+export interface TaskTestConfig extends Config {
+  testFiles: string[]
+}
+
 export interface ResolvedConfig extends Config {
   paths?: ProjectPaths
   networks: Networks

--- a/packages/algob/test/builtin-tasks/deploy.ts
+++ b/packages/algob/test/builtin-tasks/deploy.ts
@@ -2,8 +2,9 @@ import { ERRORS } from "@algo-builder/web";
 import { assert } from "chai";
 import * as fs from "fs";
 
-import { executeDeployTask as executeDeployTaskNoCLI, loadFilenames } from "../../src/builtin-tasks/deploy";
+import { executeDeployTask as executeDeployTaskNoCLI } from "../../src/builtin-tasks/deploy";
 import { TASK_DEPLOY, TASK_RUN } from "../../src/builtin-tasks/task-names";
+import { loadFilenames } from '../../src/lib/files';
 import { loadCheckpoint } from "../../src/lib/script-checkpoints";
 import { expectBuilderErrorAsync } from "../helpers/errors";
 import { testFixtureOutputFile, useCleanFixtureProject } from "../helpers/project";

--- a/packages/algob/test/builtin-tasks/deploy.ts
+++ b/packages/algob/test/builtin-tasks/deploy.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 
 import { executeDeployTask as executeDeployTaskNoCLI } from "../../src/builtin-tasks/deploy";
 import { TASK_DEPLOY, TASK_RUN } from "../../src/builtin-tasks/task-names";
-import { loadFilenames } from '../../src/lib/files';
+import { loadFilenames } from '../../src/internal/util/files';
 import { loadCheckpoint } from "../../src/lib/script-checkpoints";
 import { expectBuilderErrorAsync } from "../helpers/errors";
 import { testFixtureOutputFile, useCleanFixtureProject } from "../helpers/project";

--- a/packages/algob/test/builtin-tasks/test.ts
+++ b/packages/algob/test/builtin-tasks/test.ts
@@ -1,27 +1,11 @@
-import { ERRORS } from "@algo-builder/web";
 import { assert } from "chai";
 import path from "path";
 
 import { TASK_TEST } from "../../build/builtin-tasks/task-names";
-import { loadFilenames } from "../../src/builtin-tasks/deploy";
-import { expectBuilderError } from "../helpers/errors";
 import { useCleanFixtureProject } from "../helpers/project";
 
 describe("Test task", function () {
   useCleanFixtureProject("typescript-project");
-
-  it("Should load ts and js files from test folder", function () {
-    const ls = loadFilenames("test");
-    const expected = ['test/js-test.js', 'test/ts-test.ts'];
-    assert.deepEqual(ls, expected);
-  });
-
-  it("Should throw error if dir name is not \"test\"", function () {
-    expectBuilderError(
-      () => loadFilenames("tests", TASK_TEST), // as dir should be "test"
-      ERRORS.BUILTIN_TASKS.TESTS_DIRECTORY_NOT_FOUND
-    );
-  });
 
   it("Should set path to tsconfig in typescript project before running mocha", async function () {
     assert.isUndefined(process.env.TS_NODE_PROJECT);

--- a/packages/algob/test/internal/util/files.ts
+++ b/packages/algob/test/internal/util/files.ts
@@ -1,0 +1,23 @@
+import { ERRORS } from "@algo-builder/web";
+import { assert } from "chai";
+
+import { TASK_TEST } from "../../../src/builtin-tasks/task-names";
+import { loadFilenames } from "../../../src/internal/util/files";
+import { expectBuilderError } from "../../helpers/errors";
+import { useCleanFixtureProject } from "../../helpers/project";
+
+describe("loadFilenames", () => {
+  useCleanFixtureProject("typescript-project");
+  it("Should load ts and js files from test folder", function () {
+    const ls = loadFilenames("test");
+    const expected = ['test/js-test.js', 'test/ts-test.ts'];
+    assert.deepEqual(ls, expected);
+  });
+
+  it("Should throw error if dir name is not \"test\"", function () {
+    expectBuilderError(
+      () => loadFilenames("tests", TASK_TEST), // as dir should be "test"
+      ERRORS.BUILTIN_TASKS.TESTS_DIRECTORY_NOT_FOUND
+    );
+  });
+});

--- a/packages/algob/test/lib/files.ts
+++ b/packages/algob/test/lib/files.ts
@@ -2,7 +2,8 @@ import { ERRORS } from "@algo-builder/web";
 import { assert } from "chai";
 
 import { TASK_TEST } from "../../build/builtin-tasks/task-names";
-import { assertDirChildren, assertDirectDirChildren, loadFilenames } from "../../src/lib/files";
+import { loadFilenames } from "../../src/internal/util/files";
+import { assertDirChildren, assertDirectDirChildren } from "../../src/lib/files";
 import { expectBuilderError } from "../helpers/errors";
 import { useCleanFixtureProject } from "../helpers/project";
 
@@ -45,21 +46,5 @@ describe("assertDirectDirChildren", () => {
       () => assertDirectDirChildren("a", ["a/../b/1"]),
       ERRORS.BUILTIN_TASKS.DEPLOY_SCRIPT_NON_DIRECT_CHILD,
       "b/1");
-  });
-
-  describe("loadFilenames", () => {
-    useCleanFixtureProject("typescript-project");
-    it("Should load ts and js files from test folder", function () {
-      const ls = loadFilenames("test");
-      const expected = ['test/js-test.js', 'test/ts-test.ts'];
-      assert.deepEqual(ls, expected);
-    });
-
-    it("Should throw error if dir name is not \"test\"", function () {
-      expectBuilderError(
-        () => loadFilenames("tests", TASK_TEST), // as dir should be "test"
-        ERRORS.BUILTIN_TASKS.TESTS_DIRECTORY_NOT_FOUND
-      );
-    });
   });
 });

--- a/packages/algob/test/lib/files.ts
+++ b/packages/algob/test/lib/files.ts
@@ -1,8 +1,10 @@
 import { ERRORS } from "@algo-builder/web";
 import { assert } from "chai";
 
-import { assertDirChildren, assertDirectDirChildren } from "../../src/lib/files";
+import { TASK_TEST } from "../../build/builtin-tasks/task-names";
+import { assertDirChildren, assertDirectDirChildren, loadFilenames } from "../../src/lib/files";
 import { expectBuilderError } from "../helpers/errors";
+import { useCleanFixtureProject } from "../helpers/project";
 
 describe("assertDirChildren", () => {
   it("Should pass for children inputs", async () => {
@@ -43,5 +45,21 @@ describe("assertDirectDirChildren", () => {
       () => assertDirectDirChildren("a", ["a/../b/1"]),
       ERRORS.BUILTIN_TASKS.DEPLOY_SCRIPT_NON_DIRECT_CHILD,
       "b/1");
+  });
+
+  describe("loadFilenames", () => {
+    useCleanFixtureProject("typescript-project");
+    it("Should load ts and js files from test folder", function () {
+      const ls = loadFilenames("test");
+      const expected = ['test/js-test.js', 'test/ts-test.ts'];
+      assert.deepEqual(ls, expected);
+    });
+
+    it("Should throw error if dir name is not \"test\"", function () {
+      expectBuilderError(
+        () => loadFilenames("tests", TASK_TEST), // as dir should be "test"
+        ERRORS.BUILTIN_TASKS.TESTS_DIRECTORY_NOT_FOUND
+      );
+    });
   });
 });


### PR DESCRIPTION
## Proposed Changes

+ Move loadFilenames function(and test) from builtin-tasks/deploy.ts to lib/files.ts
+ Add addOptionalVariadicPositionalParam testFiles. Now we can run test file we want to run. 
Ex:  `algob test ./test/test.js`.


Please, review it! Thanks for your support! ❤️