### PR TITLE
sandbox-docker-compose broken by upstream changes

### DIFF
--- a/infrastructure/sandbox-docker-compose.yml
+++ b/infrastructure/sandbox-docker-compose.yml
@@ -14,7 +14,7 @@ services:
         SHA: "${ALGOD_SHA}"
         BOOTSTRAP_URL: "${NETWORK_BOOTSTRAP_URL}"
         GENESIS_FILE: "${NETWORK_GENESIS_FILE}"
-        TEMPLATE: "${NETWORK_TEMPLATE:-/tmp/images/algod/template.json}"
+        TEMPLATE: "${NETWORK_TEMPLATE:-images/algod/template.json}"
         TOKEN: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         ALGOD_PORT: "4001"
         KMD_PORT: "4002"


### PR DESCRIPTION
While upgrading to the latest Algod 3.x.x, Docker was unable to build a new algod image using the provided `make sandbox-up`.  After investigation I found that a recent change on algorand/sandbox [c3fa3acce89747b8a864ceb32890cca22a319b4d](https://github.com/algorand/sandbox/commit/c3fa3acce89747b8a864ceb32890cca22a319b4d) broke compatibility with algo-builder's provided scripts.  This pull request will resolve the issue by removing the no longer necessary `/tmp` portion of the 'TEMPLATE' variable's path

## Proposed Changes

+
+
+

## Potential followups
