### PR TITLE
Tealv5 transaction ops, TxReceipt in runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,22 @@
     * Added application account (a smart contract now has an escrow account). Updated checkpoint structure to store `applicationAccount` while running `algob` scripts.
     * Support Inner Transactions: `Payment`, `AssetTransfer`, `AssetFreeze`, `AssetRevoke`, `AssetDeploy`, `AssetModify`, `AssetDelete`.
     * Support Pooled opcode budget
+    * Txnas, Gtxnas, Gtxnsas, Args, Log (logs are stored in txReceipt)
+* Update all transaction functions (eg. `executeTx`, `addAsset`, `addApp` ..etc) to return a transaction receipt. Add `runtime.getTransactionInfo` in `@algo-builder/runtime` to query transaction info.
 
 ### Breaking changes
-
 `@algo-builder/runtime`:
 + Renamed `Runtime.getLogicSig` to `Runtime.createLsigAccount` #506.
++ `runtime.addAsset(..)`, `runtime.addApp(..)` return a tx receipt object, which contains the newly created appID/assetID.
+    * Migration: Example code:
+    ```js
+    // from
+    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram)
+
+    // to
+    const txInfo = runtime.addApp(flags, {}, approvalProgram, clearProgram);
+    const appID = txInfo.appID;
+    ```
 
 ### Bug Fixes
 +  Fix bug substring3 opcode pop wrong order [/#505](https://github.com/scale-it/algo-builder/pull/505), contribution: @vuvth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     * ExtractUint16, ExtractUint32, ExtractUint64 opcodes
     * Txn, Global fields
     * Added application account (a smart contract now has an escrow account). Updated checkpoint structure to store `applicationAccount` while running `algob` scripts.
+    * Support Inner Transactions: `Payment`, `AssetTransfer`, `AssetFreeze`, `AssetRevoke`, `AssetDeploy`, `AssetModify`, `AssetDelete`.
+    * Support Pooled opcode budget
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
     * Support Inner Transactions: `Payment`, `AssetTransfer`, `AssetFreeze`, `AssetRevoke`, `AssetDeploy`, `AssetModify`, `AssetDelete`.
     * Support Pooled opcode budget
     * Txnas, Gtxnas, Gtxnsas, Args, Log (logs are stored in txReceipt)
-* Update all transaction functions (eg. `executeTx`, `addAsset`, `addApp` ..etc) to return a transaction receipt. Add `runtime.getTransactionInfo` in `@algo-builder/runtime` to query transaction info.
+* Update all transaction functions (eg. `executeTx`, `addAsset`, `addApp` ..etc) to return a transaction receipt. Add `runtime.getTxReceipt` in `@algo-builder/runtime` to query transaction info.
 + Add Asset Name to `assetDefinition` in `@algo-builder/runtime`.
 
 ### Breaking changes

--- a/docs/guide/testing-teal.md
+++ b/docs/guide/testing-teal.md
@@ -302,7 +302,7 @@ Now, we will execute a transaction with an app call (stateful TEAL). The app is 
       globalInts: 32,
       localBytes: 8,
       localInts: 8
-    }, {}, program);
+    }, {}, program).appID;
 
     // opt-in to the app
     await runtime.optInToApp(txnParams.appID, john.address, {}, {}, program);

--- a/examples/bond/test/bond-token-flow.js
+++ b/examples/bond/test/bond-token-flow.js
@@ -82,8 +82,11 @@ describe('Bond token Tests', function () {
     * bob can exit all their tokens (12 and 2 respectively).
     */
 
-    const currentBondIndex = runtime.addAsset(
-      'bond-token-0', { creator: { ...bondTokenCreator.account, name: 'bond-token-creator' } });
+    const x = runtime.addAsset(
+      'bond-token-0',
+      { creator: { ...bondTokenCreator.account, name: 'bond-token-creator' } });
+
+    const currentBondIndex = x.assetID;
 
     const creationFlags = Object.assign({}, flags);
     const creationArgs = [
@@ -97,7 +100,7 @@ describe('Bond token Tests', function () {
 
     // create application
     applicationId = runtime.addApp(
-      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram);
+      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram).appID;
 
     // setup lsig account
     // Initialize issuer lsig with bond-app ID

--- a/examples/bond/test/bond-token-flow.js
+++ b/examples/bond/test/bond-token-flow.js
@@ -82,11 +82,9 @@ describe('Bond token Tests', function () {
     * bob can exit all their tokens (12 and 2 respectively).
     */
 
-    const x = runtime.addAsset(
+    const currentBondIndex = runtime.addAsset(
       'bond-token-0',
-      { creator: { ...bondTokenCreator.account, name: 'bond-token-creator' } });
-
-    const currentBondIndex = x.assetID;
+      { creator: { ...bondTokenCreator.account, name: 'bond-token-creator' } }).assetID;
 
     const creationFlags = Object.assign({}, flags);
     const creationArgs = [

--- a/examples/bond/test/common/common.js
+++ b/examples/bond/test/common/common.js
@@ -79,7 +79,7 @@ function createDex (runtime, creatorAccount, managerAcc, i, master, issuerLsig) 
     newBondToken,
     asaDef,
     { creator: { ...creatorAccount.account, name: 'bond-token-creator' } }
-  );
+  ).assetID;
 
   optInLsigToBond(runtime, issuerLsig, newBond, managerAcc);
 

--- a/examples/bond/test/failing-tests.js
+++ b/examples/bond/test/failing-tests.js
@@ -71,7 +71,8 @@ describe('Bond token failing tests', function () {
 
   this.beforeEach(async function () {
     initialBond = runtime.addAsset(
-      'bond-token-0', { creator: { ...bondTokenCreator.account, name: 'bond-token-creator' } });
+      'bond-token-0',
+      { creator: { ...bondTokenCreator.account, name: 'bond-token-creator' } }).assetID;
 
     const creationFlags = Object.assign({}, flags);
     const creationArgs = [
@@ -85,7 +86,7 @@ describe('Bond token failing tests', function () {
 
     // create application
     applicationId = runtime.addApp(
-      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram);
+      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram).appID;
 
     // setup lsig account
     // Initialize issuer lsig with bond-app ID

--- a/examples/crowdfunding/test/crowdfundingTest.js
+++ b/examples/crowdfunding/test/crowdfundingTest.js
@@ -93,7 +93,7 @@ describe('Crowdfunding Tests', function () {
 
     // create application
     applicationId = runtime.addApp(
-      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram);
+      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram).appID;
     const creatorPk = convert.addressToPk(creator.address);
 
     // setup escrow account
@@ -297,7 +297,7 @@ describe('Crowdfunding Tests', function () {
     // create application
     const creationFlags = Object.assign({}, flags);
     const applicationId = runtime.addApp(
-      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram);
+      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram).appID;
 
     // setup escrow account
     const escrowProg = getProgram('crowdFundEscrow.py', { APP_ID: applicationId });

--- a/examples/crowdfunding/test/failing-tests.js
+++ b/examples/crowdfunding/test/failing-tests.js
@@ -65,7 +65,7 @@ describe('Crowdfunding Test - Failing Scenarios', function () {
 
     // create application
     applicationId = runtime.addApp(
-      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram);
+      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram).appID;
 
     // setup escrow account
     const escrowProg = getProgram('crowdFundEscrow.py', { APP_ID: applicationId });

--- a/examples/crowdfunding/test/happypaths.js
+++ b/examples/crowdfunding/test/happypaths.js
@@ -103,7 +103,7 @@ describe('Crowdfunding Tests - Happy Paths', function () {
 
     // create application
     applicationId = runtime.addApp(
-      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram);
+      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram).appID;
     const creatorPk = convert.addressToPk(creator.address);
 
     assert.isDefined(applicationId);

--- a/examples/dao/test/common.js
+++ b/examples/dao/test/common.js
@@ -47,7 +47,7 @@ class Context {
   }
 
   deployASA (name, creator) {
-    this.govTokenID = this.runtime.addAsset(name, { creator: creator });
+    this.govTokenID = this.runtime.addAsset(name, { creator: creator }).assetID;
   }
 
   deployDAOApp (sender, approvalProgram, clearStateProgram) {
@@ -76,7 +76,7 @@ class Context {
 
     this.daoAppID = this.runtime.addApp(
       { ...appCreationFlags, appArgs: daoAppArgs }, {}, daoApprovalProgram, daoClearProgram
-    );
+    ).appID;
   }
 
   setUpLsig () {

--- a/examples/dao/test/dao-app-flow.js
+++ b/examples/dao/test/dao-app-flow.js
@@ -112,7 +112,7 @@ describe('DAO test', function () {
     */
 
     govTokenID = runtime.addAsset(
-      'gov-token', { creator: { ...creator.account, name: 'dao-creator' } });
+      'gov-token', { creator: { ...creator.account, name: 'dao-creator' } }).assetID;
 
     const daoAppArgs = [
       `int:${deposit}`,
@@ -127,7 +127,7 @@ describe('DAO test', function () {
 
     // create application
     appID = runtime.addApp(
-      { ...appCreationFlags, appArgs: daoAppArgs }, {}, approvalProgram, clearProgram);
+      { ...appCreationFlags, appArgs: daoAppArgs }, {}, approvalProgram, clearProgram).appID;
 
     // setup lsig accounts
     // Initialize issuer lsig with bond-app ID

--- a/examples/permissioned-token-freezing/test/asset-txfer-test.js
+++ b/examples/permissioned-token-freezing/test/asset-txfer-test.js
@@ -36,7 +36,7 @@ describe('Test for transferring asset using custom logic', function () {
     };
 
     /* Create asset + optIn to asset */
-    assetId = runtime.addAsset('gold', { creator: { ...alice.account, name: 'alice' } });
+    assetId = runtime.addAsset('gold', { creator: { ...alice.account, name: 'alice' } }).assetID;
     assetDef = runtime.getAssetDef(assetId);
     escrow = undefined;
     syncAccounts();
@@ -59,7 +59,7 @@ describe('Test for transferring asset using custom logic', function () {
       'int:2' // set min user level(2) for asset transfer ("Accred-level")
     ];
     applicationId = runtime.addApp(
-      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram);
+      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram).appID;
 
     const app = alice.getApp(applicationId);
     const alicePk = convert.addressToPk(alice.address);
@@ -252,7 +252,7 @@ describe('Test for transferring asset using custom logic', function () {
   });
 
   it('should reject transaction if minimum level is not set correctly', () => {
-    assetId = runtime.addAsset('gold', { creator: { ...alice.account, name: 'alice' } });
+    assetId = runtime.addAsset('gold', { creator: { ...alice.account, name: 'alice' } }).assetID;
     runtime.optIntoASA(assetId, bob.address, {});
 
     /* Create application + optIn to app */
@@ -262,7 +262,7 @@ describe('Test for transferring asset using custom logic', function () {
     ];
 
     applicationId = runtime.addApp(
-      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram);
+      { ...creationFlags, appArgs: creationArgs }, {}, approvalProgram, clearProgram).appID;
     const app = alice.getApp(applicationId);
     assert.isDefined(app);
 

--- a/examples/permissioned-token/test/common.js
+++ b/examples/permissioned-token/test/common.js
@@ -54,7 +54,7 @@ class Context {
   }
 
   deployASA (name, creator) {
-    this.assetIndex = this.runtime.addAsset(name, { creator: creator });
+    this.assetIndex = this.runtime.addAsset(name, { creator: creator }).assetID;
   }
 
   deployController (sender, approvalProgram, clearStateProgram) {
@@ -70,7 +70,7 @@ class Context {
     const clearProgram = getProgram(clearStateProgram);
     this.controllerappID = this.runtime.addApp(
       sscFlags, {}, controllerProgram, clearProgram
-    );
+    ).appID;
   }
 
   // Deploy Clawback Lsig and Modify Asset
@@ -114,7 +114,7 @@ class Context {
     };
     this.permissionsappID = this.runtime.addApp(
       sscFlags, {}, permissionsProgram, clearProgram
-    );
+    ).appID;
 
     // set permissions SSC app_id in controller ssc
     const appArgs = [

--- a/examples/permissioned-token/test/failing-paths.js
+++ b/examples/permissioned-token/test/failing-paths.js
@@ -760,7 +760,7 @@ describe('Permissioned Token Tests - Failing Paths', function () {
     it('should reject if asset index is incorrect even if manager is same', () => {
       // deploy new asset with same manager(alice) as original one
       const newAssetId =
-        ctx.runtime.addAsset('tesla', { creator: { ...ctx.alice.account, name: 'alice' } });
+        ctx.runtime.addAsset('tesla', { creator: { ...ctx.alice.account, name: 'alice' } }).assetID;
 
       setPermissionsParams.foreignAssets = [newAssetId];
       assert.throws(() =>

--- a/packages/algob/src/lib/script-checkpoints.ts
+++ b/packages/algob/src/lib/script-checkpoints.ts
@@ -239,7 +239,7 @@ export async function registerCheckpoints (
         const key = deployer.checkpoint.getAppCheckpointKeyFromIndex(txn.appIndex);
         if (key) {
           const temp: rtypes.SSCInfo | undefined = deployer.checkpoint.getAppfromCPKey(key);
-          if (txn.appOnComplete === Number(rtypes.TxnOnComplete.DeleteApplication) && temp) {
+          if (txn.appOnComplete === Number(rtypes.TxOnComplete.DeleteApplication) && temp) {
             temp.deleted = true;
             deployer.registerSSCInfo(key, temp);
             deployer.logTx("Deleting SSC: " + String(txn.appIndex), txConfirmation);

--- a/packages/algob/test/lib/dryrun.ts
+++ b/packages/algob/test/lib/dryrun.ts
@@ -37,7 +37,7 @@ describe("Debugging TEAL code using tealdbg", () => {
   useFixtureProject("config-project");
   let deployer: Deployer;
   let algod: AlgoOperatorDryRunImpl;
-  let txnParam: ExecParams;
+  let txParam: ExecParams;
   let tealDebugger: TealDbgMock;
 
   beforeEach(async () => {
@@ -57,7 +57,7 @@ describe("Debugging TEAL code using tealdbg", () => {
     (sinon.stub(algod.algodClient, "getApplicationByID") as any)
       .returns({ do: async () => mockApplicationResponse }) as ReturnType<algosdk.Algodv2['getApplicationByID']>;
 
-    txnParam = {
+    txParam = {
       type: types.TransactionType.TransferAsset,
       sign: types.SignType.LogicSignature,
       fromAccountAddr: generateAccount().addr,
@@ -67,7 +67,7 @@ describe("Debugging TEAL code using tealdbg", () => {
       lsig: mockLsig,
       payFlags: { totalFee: 1000 }
     };
-    tealDebugger = new TealDbgMock(deployer, txnParam);
+    tealDebugger = new TealDbgMock(deployer, txParam);
   });
 
   afterEach(async () => {
@@ -141,7 +141,7 @@ describe("Debugging TEAL code using tealdbg", () => {
   });
 
   it("should throw error if groupIndex is greator than txGroup length", async () => {
-    tealDebugger.execParams = [txnParam, { ...txnParam, payFlags: { note: 'Algrand' } }];
+    tealDebugger.execParams = [txParam, { ...txParam, payFlags: { note: 'Algrand' } }];
 
     try {
       await tealDebugger.run({ mode: ExecutionMode.APPLICATION, groupIndex: 5 });

--- a/packages/runtime/src/ctx.ts
+++ b/packages/runtime/src/ctx.ts
@@ -11,16 +11,16 @@ import {
   AccountAddress, AccountStoreI,
   AppDeploymentFlags,
   ASADeploymentFlags, AssetHoldingM,
-  Context, DeployedAppTxReceipt, DeployedAssetTxReceipt, ExecutionMode,
-  ID, SSCAttributesM, StackElem, State, Txn, TxReceipt
+  Context, DeployedAppTxReceipt, DeployedAssetTxReceipt, EncTx, ExecutionMode,
+  ID, SSCAttributesM, StackElem, State, TxReceipt
 } from "./types";
 
 const APPROVAL_PROGRAM = "approval-program";
 
 export class Ctx implements Context {
   state: State;
-  tx: Txn;
-  gtxs: Txn[];
+  tx: EncTx;
+  gtxs: EncTx[];
   args: Uint8Array[];
   runtime: Runtime;
   debugStack?: number; //  max number of top elements from the stack to print after each opcode execution.
@@ -31,7 +31,7 @@ export class Ctx implements Context {
   isInnerTx: boolean; // true if "ctx" is switched to an inner transaction
   createdAssetID: number; // Asset ID allocated by the creation of an ASA (for an inner-tx)
 
-  constructor (state: State, tx: Txn, gtxs: Txn[], args: Uint8Array[],
+  constructor (state: State, tx: EncTx, gtxs: EncTx[], args: Uint8Array[],
     runtime: Runtime, debugStack?: number) {
     this.state = state;
     this.tx = tx;

--- a/packages/runtime/src/ctx.ts
+++ b/packages/runtime/src/ctx.ts
@@ -49,9 +49,9 @@ export class Ctx implements Context {
     this.createdAssetID = 0;
   }
 
-  private setAndGetTxnInfo (): TxReceipt {
+  private setAndGetTxReceipt (): TxReceipt {
     const info = { txn: this.tx, txID: this.tx.txID };
-    this.state.txnInfo.set(this.tx.txID, info);
+    this.state.txReceipts.set(this.tx.txID, info);
     return info;
   }
 
@@ -159,7 +159,7 @@ export class Ctx implements Context {
       closeRemToAcc.amount += fromAccount.amount; // transfer funds of sender to closeRemTo account
       fromAccount.amount = 0n; // close sender's account
     }
-    return this.setAndGetTxnInfo();
+    return this.setAndGetTxReceipt();
   }
 
   /**
@@ -216,7 +216,7 @@ export class Ctx implements Context {
       txID: this.tx.txID,
       assetID: this.state.assetCounter
     };
-    this.state.txnInfo.set(this.tx.txID, receipt);
+    this.state.txReceipts.set(this.tx.txID, receipt);
     return receipt;
   }
 
@@ -241,7 +241,7 @@ export class Ctx implements Context {
     const account = this.getAccount(address);
     account.optInToASA(assetIndex, assetHolding);
     this.assertAccBalAboveMin(address);
-    return this.setAndGetTxnInfo();
+    return this.setAndGetTxReceipt();
   }
 
   /**
@@ -308,7 +308,7 @@ export class Ctx implements Context {
     this.state.accounts.set(acc.address, acc);
 
     // set & return transaction receipt
-    const receipt = this.state.txnInfo.get(this.tx.txID) as DeployedAppTxReceipt;
+    const receipt = this.state.txReceipts.get(this.tx.txID) as DeployedAppTxReceipt;
     receipt.appID = this.state.appCounter;
     return receipt;
   }
@@ -414,7 +414,7 @@ export class Ctx implements Context {
       const fromAccount = this.getAccount(fromAccountAddr);
       fromAccount.closeAsset(txnParam.assetID as number);
     }
-    return this.setAndGetTxnInfo();
+    return this.setAndGetTxReceipt();
   }
 
   /**
@@ -426,7 +426,7 @@ export class Ctx implements Context {
   modifyAsset (assetId: number, fields: types.AssetModFields): TxReceipt {
     const creatorAcc = this.getAssetAccount(assetId);
     creatorAcc.modifyAsset(assetId, fields);
-    return this.setAndGetTxnInfo();
+    return this.setAndGetTxReceipt();
   }
 
   /**
@@ -444,7 +444,7 @@ export class Ctx implements Context {
       this.state.accounts.get(freezeTarget)
     );
     acc.setFreezeState(assetId, freezeState);
-    return this.setAndGetTxnInfo();
+    return this.setAndGetTxReceipt();
   }
 
   /**
@@ -472,7 +472,7 @@ export class Ctx implements Context {
     }
     fromAssetHolding.amount -= amount;
     toAssetHolding.amount += amount;
-    return this.setAndGetTxnInfo();
+    return this.setAndGetTxReceipt();
   }
 
   /**
@@ -488,7 +488,7 @@ export class Ctx implements Context {
     this.state.accounts.forEach((value, key) => {
       value.assets.delete(assetId);
     });
-    return this.setAndGetTxnInfo();
+    return this.setAndGetTxReceipt();
   }
 
   /**

--- a/packages/runtime/src/ctx.ts
+++ b/packages/runtime/src/ctx.ts
@@ -11,7 +11,7 @@ import {
   AccountAddress, AccountStoreI,
   AppDeploymentFlags,
   ASADeploymentFlags, AssetHoldingM,
-  Context, ExecutionMode,
+  Context, DeployedAppTxReceipt, DeployedAssetTxReceipt, ExecutionMode,
   ID, SSCAttributesM, StackElem, State, Txn, TxReceipt
 } from "./types";
 
@@ -171,7 +171,7 @@ export class Ctx implements Context {
   addAsset (
     name: string,
     fromAccountAddr: AccountAddress, flags: ASADeploymentFlags
-  ): TxReceipt {
+  ): DeployedAssetTxReceipt {
     return this.addASADef(
       name, this.runtime.loadedAssetsDefs[name], fromAccountAddr, flags
     );
@@ -187,7 +187,7 @@ export class Ctx implements Context {
   addASADef (
     name: string, asaDef: types.ASADef,
     fromAccountAddr: AccountAddress, flags: ASADeploymentFlags
-  ): TxReceipt {
+  ): DeployedAssetTxReceipt {
     const senderAcc = this.getAccount(fromAccountAddr);
     parseASADef(asaDef);
     validateOptInAccNames(this.state.accountNameAddress, asaDef);
@@ -259,7 +259,7 @@ export class Ctx implements Context {
   addApp (
     fromAccountAddr: AccountAddress, flags: AppDeploymentFlags,
     approvalProgram: string, clearProgram: string, idx: number
-  ): TxReceipt {
+  ): DeployedAppTxReceipt {
     const senderAcc = this.getAccount(fromAccountAddr);
 
     if (approvalProgram === "") {
@@ -308,7 +308,7 @@ export class Ctx implements Context {
     this.state.accounts.set(acc.address, acc);
 
     // set & return transaction receipt
-    const receipt = this.state.txnInfo.get(this.tx.txID) as TxReceipt;
+    const receipt = this.state.txnInfo.get(this.tx.txID) as DeployedAppTxReceipt;
     receipt.appID = this.state.appCounter;
     return receipt;
   }
@@ -681,7 +681,7 @@ export class Ctx implements Context {
           } else {
             r = this.addAsset(txnParam.asaName, fromAccountAddr, flags);
           }
-          this.knowableID.set(idx, r.assetID as number);
+          this.knowableID.set(idx, (r as DeployedAssetTxReceipt).assetID);
           break;
         }
         case types.TransactionType.OptInASA: {
@@ -705,7 +705,7 @@ export class Ctx implements Context {
             txnParam.clearProgram,
             idx
           );
-          this.knowableID.set(idx, r.appID as number);
+          this.knowableID.set(idx, (r as DeployedAppTxReceipt).appID);
           break;
         }
         case types.TransactionType.OptInToApp: {

--- a/packages/runtime/src/ctx.ts
+++ b/packages/runtime/src/ctx.ts
@@ -144,17 +144,17 @@ export class Ctx implements Context {
   }
 
   // transfer ALGO as per transaction parameters
-  transferAlgo (txnParam: types.AlgoTransferParam): TxReceipt {
-    const fromAccount = this.getAccount(webTx.getFromAddress(txnParam));
-    const toAccount = this.getAccount(txnParam.toAccountAddr);
-    txnParam.amountMicroAlgos = BigInt(txnParam.amountMicroAlgos);
+  transferAlgo (txParam: types.AlgoTransferParam): TxReceipt {
+    const fromAccount = this.getAccount(webTx.getFromAddress(txParam));
+    const toAccount = this.getAccount(txParam.toAccountAddr);
+    txParam.amountMicroAlgos = BigInt(txParam.amountMicroAlgos);
 
-    fromAccount.amount -= txnParam.amountMicroAlgos; // remove 'x' algo from sender
-    toAccount.amount += BigInt(txnParam.amountMicroAlgos); // add 'x' algo to receiver
+    fromAccount.amount -= txParam.amountMicroAlgos; // remove 'x' algo from sender
+    toAccount.amount += BigInt(txParam.amountMicroAlgos); // add 'x' algo to receiver
     this.assertAccBalAboveMin(fromAccount.address);
 
-    if (txnParam.payFlags.closeRemainderTo) {
-      const closeRemToAcc = this.getAccount(txnParam.payFlags.closeRemainderTo);
+    if (txParam.payFlags.closeRemainderTo) {
+      const closeRemToAcc = this.getAccount(txParam.payFlags.closeRemainderTo);
 
       closeRemToAcc.amount += fromAccount.amount; // transfer funds of sender to closeRemTo account
       fromAccount.amount = 0n; // close sender's account
@@ -346,7 +346,7 @@ export class Ctx implements Context {
    * https://developer.algorand.org/articles/introducing-algorand-virtual-machine-avm-09-release/
    */
   verifyMinimumFees (): void {
-    if (this.isInnerTx) { return; } // pooled fee for inner tx is calculated at itxn_submit
+    if (this.isInnerTx) { return; } // pooled fee for inner tx is calculated at itx_submit
     let collected = 0;
     for (const val of this.gtxs) {
       if (val.fee === undefined) val.fee = 0;
@@ -379,40 +379,40 @@ export class Ctx implements Context {
   }
 
   // transfer ASSET as per transaction parameters
-  transferAsset (txnParam: types.AssetTransferParam): TxReceipt {
-    const fromAccountAddr = webTx.getFromAddress(txnParam);
-    txnParam.amount = BigInt(txnParam.amount);
-    if (txnParam.amount === 0n && fromAccountAddr === txnParam.toAccountAddr) {
-      this.optIntoASA(txnParam.assetID as number, fromAccountAddr, txnParam.payFlags);
-    } else if (txnParam.amount !== 0n) {
-      this.assertAssetNotFrozen(txnParam.assetID as number, fromAccountAddr);
-      this.assertAssetNotFrozen(txnParam.assetID as number, txnParam.toAccountAddr);
+  transferAsset (txParam: types.AssetTransferParam): TxReceipt {
+    const fromAccountAddr = webTx.getFromAddress(txParam);
+    txParam.amount = BigInt(txParam.amount);
+    if (txParam.amount === 0n && fromAccountAddr === txParam.toAccountAddr) {
+      this.optIntoASA(txParam.assetID as number, fromAccountAddr, txParam.payFlags);
+    } else if (txParam.amount !== 0n) {
+      this.assertAssetNotFrozen(txParam.assetID as number, fromAccountAddr);
+      this.assertAssetNotFrozen(txParam.assetID as number, txParam.toAccountAddr);
     }
 
-    const fromAssetHolding = this.getAssetHolding(txnParam.assetID as number, fromAccountAddr);
-    const toAssetHolding = this.getAssetHolding(txnParam.assetID as number, txnParam.toAccountAddr);
-    if (fromAssetHolding.amount - txnParam.amount < 0) {
+    const fromAssetHolding = this.getAssetHolding(txParam.assetID as number, fromAccountAddr);
+    const toAssetHolding = this.getAssetHolding(txParam.assetID as number, txParam.toAccountAddr);
+    if (fromAssetHolding.amount - txParam.amount < 0) {
       throw new RuntimeError(RUNTIME_ERRORS.TRANSACTION.INSUFFICIENT_ACCOUNT_ASSETS, {
-        amount: txnParam.amount,
+        amount: txParam.amount,
         address: fromAccountAddr
       });
     }
-    fromAssetHolding.amount -= txnParam.amount;
-    toAssetHolding.amount += BigInt(txnParam.amount);
+    fromAssetHolding.amount -= txParam.amount;
+    toAssetHolding.amount += BigInt(txParam.amount);
 
-    if (txnParam.payFlags.closeRemainderTo) {
-      const closeToAddr = txnParam.payFlags.closeRemainderTo;
+    if (txParam.payFlags.closeRemainderTo) {
+      const closeToAddr = txParam.payFlags.closeRemainderTo;
       if (fromAccountAddr === fromAssetHolding.creator) {
         throw new RuntimeError(RUNTIME_ERRORS.ASA.CANNOT_CLOSE_ASSET_BY_CREATOR);
       }
-      this.assertAssetNotFrozen(txnParam.assetID as number, closeToAddr);
+      this.assertAssetNotFrozen(txParam.assetID as number, closeToAddr);
 
       const closeRemToAssetHolding = this.getAssetHolding(
-        txnParam.assetID as number, closeToAddr);
+        txParam.assetID as number, closeToAddr);
 
       closeRemToAssetHolding.amount += fromAssetHolding.amount; // transfer assets of sender to closeRemTo account
       const fromAccount = this.getAccount(fromAccountAddr);
-      fromAccount.closeAsset(txnParam.assetID as number);
+      fromAccount.closeAsset(txParam.assetID as number);
     }
     return this.setAndGetTxReceipt();
   }
@@ -560,58 +560,58 @@ export class Ctx implements Context {
    * Note: we're doing this because if any one tx in group fails,
    * then it does not affect runtime.store, otherwise we just update
    * store with ctx (if all transactions are executed successfully).
-   * @param txnParams Transaction Parameters
+   * @param txParams Transaction Parameters
    */
   /* eslint-disable sonarjs/cognitive-complexity */
-  processTransactions (txnParams: types.ExecParams[]): TxReceipt[] {
+  processTransactions (txParams: types.ExecParams[]): TxReceipt[] {
     const txReceipts: TxReceipt[] = [];
     let r: TxReceipt;
 
     this.verifyMinimumFees();
-    txnParams.forEach((txnParam, idx) => {
-      const fromAccountAddr = webTx.getFromAddress(txnParam);
-      this.deductFee(fromAccountAddr, idx, txnParam.payFlags);
+    txParams.forEach((txParam, idx) => {
+      const fromAccountAddr = webTx.getFromAddress(txParam);
+      this.deductFee(fromAccountAddr, idx, txParam.payFlags);
 
-      if (txnParam.sign === types.SignType.LogicSignature) {
+      if (txParam.sign === types.SignType.LogicSignature) {
         this.tx = this.gtxs[idx]; // update current tx to index of stateless
-        r = this.runtime.validateLsigAndRun(txnParam, this.debugStack);
+        r = this.runtime.validateLsigAndRun(txParam, this.debugStack);
         this.tx = this.gtxs[0]; // after executing stateless tx updating current tx to default (index 0)
       }
 
       // https://developer.algorand.org/docs/features/asc1/stateful/#the-lifecycle-of-a-stateful-smart-contract
-      switch (txnParam.type) {
+      switch (txParam.type) {
         case types.TransactionType.TransferAlgo: {
-          r = this.transferAlgo(txnParam);
+          r = this.transferAlgo(txParam);
           break;
         }
         case types.TransactionType.TransferAsset: {
-          r = this.transferAsset(txnParam);
+          r = this.transferAsset(txParam);
           break;
         }
         case types.TransactionType.CallApp: {
           this.tx = this.gtxs[idx]; // update current tx to the requested index
-          const appParams = this.getApp(txnParam.appID);
+          const appParams = this.getApp(txParam.appID);
           r = this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, idx, this.debugStack);
           break;
         }
         case types.TransactionType.CloseApp: {
           this.tx = this.gtxs[idx]; // update current tx to the requested index
-          const appParams = this.getApp(txnParam.appID);
+          const appParams = this.getApp(txParam.appID);
           r = this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, idx, this.debugStack);
-          this.closeApp(fromAccountAddr, txnParam.appID);
+          this.closeApp(fromAccountAddr, txParam.appID);
           break;
         }
         case types.TransactionType.UpdateApp: {
           this.tx = this.gtxs[idx]; // update current tx to the requested index
 
           r = this.updateApp(
-            txnParam.appID, txnParam.newApprovalProgram, txnParam.newClearProgram, idx
+            txParam.appID, txParam.newApprovalProgram, txParam.newClearProgram, idx
           );
           break;
         }
         case types.TransactionType.ClearApp: {
           this.tx = this.gtxs[idx]; // update current tx to the requested index
-          const appParams = this.runtime.assertAppDefined(txnParam.appID, this.getApp(txnParam.appID));
+          const appParams = this.runtime.assertAppDefined(txParam.appID, this.getApp(txParam.appID));
           try {
             r = this.runtime.run(appParams["clear-state-program"], ExecutionMode.APPLICATION, idx, this.debugStack);
           } catch (error) {
@@ -620,98 +620,98 @@ export class Ctx implements Context {
             // https://developer.algorand.org/docs/features/asc1/stateful/#the-lifecycle-of-a-stateful-smart-contract
           }
 
-          this.closeApp(fromAccountAddr, txnParam.appID); // remove app from local state
+          this.closeApp(fromAccountAddr, txParam.appID); // remove app from local state
           break;
         }
         case types.TransactionType.DeleteApp: {
           this.tx = this.gtxs[idx]; // update current tx to the requested index
-          const appParams = this.getApp(txnParam.appID);
+          const appParams = this.getApp(txParam.appID);
           r = this.runtime.run(appParams[APPROVAL_PROGRAM], ExecutionMode.APPLICATION, idx, this.debugStack);
-          this.deleteApp(txnParam.appID);
+          this.deleteApp(txParam.appID);
           break;
         }
         case types.TransactionType.ModifyAsset: {
-          const asset = this.getAssetDef(txnParam.assetID as number);
+          const asset = this.getAssetDef(txParam.assetID as number);
           if (asset.manager !== fromAccountAddr) {
             throw new RuntimeError(RUNTIME_ERRORS.ASA.MANAGER_ERROR, { address: asset.manager });
           }
           // modify asset in ctx.
-          r = this.modifyAsset(txnParam.assetID as number, txnParam.fields);
+          r = this.modifyAsset(txParam.assetID as number, txParam.fields);
           break;
         }
         case types.TransactionType.FreezeAsset: {
-          const asset = this.getAssetDef(txnParam.assetID as number);
+          const asset = this.getAssetDef(txParam.assetID as number);
           if (asset.freeze !== fromAccountAddr) {
             throw new RuntimeError(RUNTIME_ERRORS.ASA.FREEZE_ERROR, { address: asset.freeze });
           }
-          r = this.freezeAsset(txnParam.assetID as number, txnParam.freezeTarget, txnParam.freezeState);
+          r = this.freezeAsset(txParam.assetID as number, txParam.freezeTarget, txParam.freezeState);
           break;
         }
         case types.TransactionType.RevokeAsset: {
-          const asset = this.getAssetDef(txnParam.assetID as number);
+          const asset = this.getAssetDef(txParam.assetID as number);
           if (asset.clawback !== fromAccountAddr) {
             throw new RuntimeError(RUNTIME_ERRORS.ASA.CLAWBACK_ERROR, { address: asset.clawback });
           }
-          if (txnParam.payFlags.closeRemainderTo) {
+          if (txParam.payFlags.closeRemainderTo) {
             throw new RuntimeError(RUNTIME_ERRORS.ASA.CANNOT_CLOSE_ASSET_BY_CLAWBACK);
           }
           r = this.revokeAsset(
-            txnParam.recipient, txnParam.assetID as number,
-            txnParam.revocationTarget, BigInt(txnParam.amount)
+            txParam.recipient, txParam.assetID as number,
+            txParam.revocationTarget, BigInt(txParam.amount)
           );
           break;
         }
         case types.TransactionType.DestroyAsset: {
-          const asset = this.getAssetDef(txnParam.assetID as number);
+          const asset = this.getAssetDef(txParam.assetID as number);
           if (asset.manager !== fromAccountAddr) {
             throw new RuntimeError(RUNTIME_ERRORS.ASA.MANAGER_ERROR, { address: asset.manager });
           }
-          r = this.destroyAsset(txnParam.assetID as number);
+          r = this.destroyAsset(txParam.assetID as number);
           break;
         }
         case types.TransactionType.DeployASA: {
           this.tx = this.gtxs[idx]; // update current tx to the requested index
           const senderAcc = this.getAccount(fromAccountAddr);
           const flags: ASADeploymentFlags = {
-            ...txnParam.payFlags,
+            ...txParam.payFlags,
             creator: { ...senderAcc.account, name: senderAcc.address }
           };
-          if (txnParam.asaDef) {
-            r = this.addASADef(txnParam.asaName, txnParam.asaDef, fromAccountAddr, flags);
+          if (txParam.asaDef) {
+            r = this.addASADef(txParam.asaName, txParam.asaDef, fromAccountAddr, flags);
           } else {
-            r = this.addAsset(txnParam.asaName, fromAccountAddr, flags);
+            r = this.addAsset(txParam.asaName, fromAccountAddr, flags);
           }
           this.knowableID.set(idx, (r as DeployedAssetTxReceipt).assetID);
           break;
         }
         case types.TransactionType.OptInASA: {
-          r = this.optIntoASA(txnParam.assetID as number, fromAccountAddr, txnParam.payFlags);
+          r = this.optIntoASA(txParam.assetID as number, fromAccountAddr, txParam.payFlags);
           break;
         }
         case types.TransactionType.DeployApp: {
           const senderAcc = this.getAccount(fromAccountAddr);
           const flags: AppDeploymentFlags = {
             sender: senderAcc.account,
-            localInts: txnParam.localInts,
-            localBytes: txnParam.localBytes,
-            globalInts: txnParam.globalInts,
-            globalBytes: txnParam.globalBytes
+            localInts: txParam.localInts,
+            localBytes: txParam.localBytes,
+            globalInts: txParam.globalInts,
+            globalBytes: txParam.globalBytes
           };
           this.tx = this.gtxs[idx]; // update current tx to the requested index
 
           r = this.addApp(
             fromAccountAddr, flags,
-            txnParam.approvalProgram,
-            txnParam.clearProgram,
+            txParam.approvalProgram,
+            txParam.clearProgram,
             idx
           );
           this.knowableID.set(idx, (r as DeployedAppTxReceipt).appID);
           break;
         }
         case types.TransactionType.OptInToApp: {
-          this.tx = this.gtxs[idx]; // update current tx to txn being exectuted in group
+          this.tx = this.gtxs[idx]; // update current tx to tx being exectuted in group
 
-          r = this.optInToApp(fromAccountAddr, txnParam.appID, idx);
+          r = this.optInToApp(fromAccountAddr, txParam.appID, idx);
           break;
         }
       }

--- a/packages/runtime/src/ctx.ts
+++ b/packages/runtime/src/ctx.ts
@@ -26,6 +26,7 @@ export class Ctx implements Context {
   debugStack?: number; //  max number of top elements from the stack to print after each opcode execution.
   sharedScratchSpace: Map<number, StackElem[]>; // here number is index of transaction in a group
   knowableID: Map<number, ID>; // here number is index of transaction in a group
+  pooledApplCost: number; // total opcode cost for each application call for single/group tx
   // inner transaction props
   isInnerTx: boolean; // true if "ctx" is switched to an inner transaction
   createdAssetID: number; // Asset ID allocated by the creation of an ASA (for an inner-tx)
@@ -42,6 +43,7 @@ export class Ctx implements Context {
     // Scratch space is a list of elements.
     this.sharedScratchSpace = new Map<number, StackElem[]>();
     this.knowableID = new Map<number, ID>();
+    this.pooledApplCost = 0;
     // inner transaction props
     this.isInnerTx = false;
     this.createdAssetID = 0;

--- a/packages/runtime/src/errors/errors-list.ts
+++ b/packages/runtime/src/errors/errors-list.ts
@@ -340,6 +340,18 @@ maximun uint128`
     message: "Address %address% is not a valid Algorand address, at line %line%",
     title: "Address not valid",
     description: `Address not valid`
+  },
+  LOGS_COUNT_EXCEEDED_THRESHOLD: {
+    number: 1051,
+    message: "Maximum number of logs exceeded threshold of %maxLogs%, at line %line%",
+    title: "Maximum number of logs exceeded",
+    description: `Maximum number of logs exceeded`
+  },
+  LOGS_LENGTH_EXCEEDED_THRESHOLD: {
+    number: 1052,
+    message: "Maximum length (in bytes) of logs exceeded threshold of %maxLength%, but got %origLength%, at line %line%",
+    title: "Maximum length (in bytes) of logs exceeded",
+    description: `Maximum length (in bytes) of logs exceeded`
   }
 };
 

--- a/packages/runtime/src/interpreter/interpreter.ts
+++ b/packages/runtime/src/interpreter/interpreter.ts
@@ -433,7 +433,7 @@ export class Interpreter {
     while (this.instructionIndex < this.instructions.length) {
       const instruction = this.instructions[this.instructionIndex];
       instruction.execute(this.stack);
-      const txReceipt = this.runtime.ctx.state.txnInfo.get(this.runtime.ctx.tx.txID) as TxReceipt;
+      const txReceipt = this.runtime.ctx.state.txReceipts.get(this.runtime.ctx.tx.txID) as TxReceipt;
 
       // for teal version >= 4, cost is calculated dynamically at the time of execution
       // for teal version < 4, cost is handled statically during parsing

--- a/packages/runtime/src/interpreter/interpreter.ts
+++ b/packages/runtime/src/interpreter/interpreter.ts
@@ -9,8 +9,8 @@ import { keyToBytes } from "../lib/parsing";
 import { Stack } from "../lib/stack";
 import { assertMaxCost, parser } from "../parser/parser";
 import {
-  AccountStoreI, ExecutionMode, Operator, SSCAttributesM,
-  StackElem, TEALStack, Txn, TxReceipt
+  AccountStoreI, EncTx, ExecutionMode, Operator, SSCAttributesM,
+  StackElem, TEALStack, TxReceipt
 } from "../types";
 import { Op } from "./opcode";
 import { Label } from "./opcode-list";
@@ -41,8 +41,8 @@ export class Interpreter {
   // It is used to provide sub routine functionality
   callStack: Stack<number>;
   labelMap: Map<string, number>; // label string mapped to their respective indexes in instructions array
-  subTxn: Txn | undefined; // "current" inner transaction
-  innerTxns: Txn[]; // executed inner transactions
+  subTxn: EncTx | undefined; // "current" inner transaction
+  innerTxns: EncTx[]; // executed inner transactions
 
   constructor () {
     this.stack = new Stack<StackElem>();

--- a/packages/runtime/src/interpreter/opcode-list.ts
+++ b/packages/runtime/src/interpreter/opcode-list.ts
@@ -25,7 +25,7 @@ import {
 } from "../lib/parsing";
 import { Stack } from "../lib/stack";
 import { txAppArg, txnSpecbyField } from "../lib/txn";
-import { DecodingMode, EncodingType, StackElem, TEALStack, TxnOnComplete, TxnType, TxReceipt } from "../types";
+import { DecodingMode, EncodingType, StackElem, TEALStack, TxnType, TxOnComplete, TxReceipt } from "../types";
 import { Interpreter } from "./interpreter";
 import { Op } from "./opcode";
 
@@ -2140,10 +2140,10 @@ export class Int extends Op {
     assertLen(args.length, 1, line);
 
     let uint64;
-    const intConst = TxnOnComplete[args[0] as keyof typeof TxnOnComplete] ||
+    const intConst = TxOnComplete[args[0] as keyof typeof TxOnComplete] ||
       TxnType[args[0] as keyof typeof TxnType];
 
-    // check if string is keyof TxnOnComplete or TxnType
+    // check if string is keyof TxOnComplete or TxnType
     if (intConst !== undefined) {
       uint64 = BigInt(intConst);
     } else {

--- a/packages/runtime/src/interpreter/opcode-list.ts
+++ b/packages/runtime/src/interpreter/opcode-list.ts
@@ -4204,7 +4204,7 @@ export class Log extends Op {
     this.assertMinStackLen(stack, 1, this.line);
     const logByte = this.assertBytes(stack.pop(), this.line);
     const txID = this.interpreter.runtime.ctx.tx.txID;
-    const txReceipt = this.interpreter.runtime.ctx.state.txnInfo.get(txID) as TxReceipt;
+    const txReceipt = this.interpreter.runtime.ctx.state.txReceipts.get(txID) as TxReceipt;
     if (txReceipt.logs === undefined) { txReceipt.logs = []; }
 
     // max no. of logs exceeded

--- a/packages/runtime/src/lib/constants.ts
+++ b/packages/runtime/src/lib/constants.ts
@@ -389,3 +389,16 @@ export const TxnTypeMap: {[key: string]: string} = {
   4: 'axfer', // TransferAsset OR RevokeAsset,
   5: 'afrz'
 };
+
+/**
+ * https://developer.algorand.org/docs/get-details/dapps/avm/teal/specification/#typeenum-constants
+ */
+export enum TransactionTypeEnum {
+  UNKNOWN = "unknown",
+  PAYMENT = "pay",
+  KEY_REGISTRATION = "keyreg",
+  ASSET_CONFIG = "acfg",
+  ASSET_TRANSFER = "axfer",
+  ASSET_FREEZE = "afrz",
+  APPLICATION_CALL = "appl",
+}

--- a/packages/runtime/src/lib/constants.ts
+++ b/packages/runtime/src/lib/constants.ts
@@ -349,7 +349,10 @@ OpGasCost[4] = {
  * teal v5
  */
 OpGasCost[5] = {
-  ...OpGasCost[4]
+  ...OpGasCost[4],
+  ecdsa_verify: 1700,
+  ecdsa_pk_decompress: 650,
+  ecdsa_pk_recover: 2000
 };
 
 export const enum MathOp {

--- a/packages/runtime/src/lib/constants.ts
+++ b/packages/runtime/src/lib/constants.ts
@@ -32,6 +32,8 @@ export const ALGORAND_MAX_TX_ACCOUNTS_LEN = 4;
 // the assets and application arrays combined and totaled with the accounts array can not exceed 8
 export const ALGORAND_MAX_TX_ARRAY_LEN = 8;
 export const MAX_INNER_TRANSACTIONS = 16;
+export const ALGORAND_MAX_LOGS_COUNT = 32;
+export const ALGORAND_MAX_LOGS_LENGTH = 1024;
 
 export const MAX_ALGORAND_ACCOUNT_ASSETS = 1000;
 export const MAX_ALGORAND_ACCOUNT_CREATED_APPS = 10;

--- a/packages/runtime/src/lib/itxn.ts
+++ b/packages/runtime/src/lib/itxn.ts
@@ -6,7 +6,7 @@ import { RUNTIME_ERRORS } from "../errors/errors-list";
 import { RuntimeError } from "../errors/runtime-errors";
 import { Op } from "../interpreter/opcode";
 import { TxnFields, TxnTypeMap, ZERO_ADDRESS_STR } from "../lib/constants";
-import { AccountAddress, RuntimeAccount, StackElem, Txn } from "../types";
+import { AccountAddress, EncTx, RuntimeAccount, StackElem } from "../types";
 import { convertToString } from "./parsing";
 import { assetTxnFields, isEncTxAssetConfig, isEncTxAssetDeletion } from "./txn";
 
@@ -43,8 +43,8 @@ const addrTxnFields = new Set([
  */
 /* eslint-disable sonarjs/cognitive-complexity */
 export function setInnerTxField (
-  subTxn: Txn, field: string, val: StackElem,
-  op: Op, interpreter: Interpreter, line: number): Txn {
+  subTxn: EncTx, field: string, val: StackElem,
+  op: Op, interpreter: Interpreter, line: number): EncTx {
   let txValue: bigint | number | string | Uint8Array | undefined;
   if (uintTxnFields.has(field)) {
     txValue = op.assertBigInt(val, line);
@@ -185,7 +185,7 @@ const _getRuntimeAccountAddr = (publickey: Buffer | undefined,
 
 // parse encoded txn obj to execParams (params passed by user in algob)
 /* eslint-disable sonarjs/cognitive-complexity */
-export function parseEncodedTxnToExecParams (tx: Txn,
+export function parseEncodedTxnToExecParams (tx: EncTx,
   interpreter: Interpreter, line: number): types.ExecParams {
   // initial common fields
   const execParams: any = {

--- a/packages/runtime/src/parser/parser.ts
+++ b/packages/runtime/src/parser/parser.ts
@@ -4,7 +4,7 @@ import { Interpreter } from "../interpreter/interpreter";
 import {
   Add, Addr, Addw, And, AppGlobalDel, AppGlobalGet, AppGlobalGetEx,
   AppGlobalPut, AppLocalDel, AppLocalGet, AppLocalGetEx, AppLocalPut,
-  AppOptedIn, Arg, Assert, Balance, BitwiseAnd, BitwiseNot, BitwiseOr,
+  AppOptedIn, Arg, Args, Assert, Balance, BitwiseAnd, BitwiseNot, BitwiseOr,
   BitwiseXor, Branch, BranchIfNotZero, BranchIfNotZerov4, BranchIfZero, BranchIfZerov4, Branchv4,
   Btoi, Byte, ByteAdd, ByteBitwiseAnd, ByteBitwiseInvert, ByteBitwiseOr,
   ByteBitwiseXor, Bytec, Bytecblock, ByteDiv, ByteEqualTo, ByteGreaterThanEqualTo, ByteGreatorThan,
@@ -14,12 +14,12 @@ import {
   EqualTo, Err, Exp, Expw, Extract, Extract3, ExtractUint16,
   ExtractUint32, ExtractUint64, Gaid, Gaids, GetAssetDef, GetAssetHolding,
   GetBit, GetByte, Gload, Gloads, Global, GreaterThan,
-  GreaterThanEqualTo, Gtxn, Gtxna, Gtxns, Gtxnsa, Int, Intc, Intcblock, Itob,
+  GreaterThanEqualTo, Gtxn, Gtxna, Gtxnas, Gtxns, Gtxnsa, Gtxnsas, Int, Intc, Intcblock, Itob,
   ITxn, ITxna, ITxnBegin, ITxnField, ITxnSubmit,
-  Keccak256, Label, Len, LessThan, LessThanEqualTo, Load, Loads, MinBalance, Mod,
+  Keccak256, Label, Len, LessThan, LessThanEqualTo, Load, Loads, Log, MinBalance, Mod,
   Mul, Mulw, Not, NotEqualTo, Or, Pop, Pragma, PushBytes, PushInt, Retsub,
   Return, Select, SetBit, SetByte, Sha256,
-  Sha512_256, Shl, Shr, Sqrt, Store, Stores, Sub, Substring, Substring3, Swap, Txn, Txna, Uncover
+  Sha512_256, Shl, Shr, Sqrt, Store, Stores, Sub, Substring, Substring3, Swap, Txn, Txna, Txnas, Uncover
 } from "../interpreter/opcode-list";
 import { LogicSigMaxCost, LogicSigMaxSize, MaxAppProgramCost, MaxAppProgramLen, OpGasCost } from "../lib/constants";
 import { assertLen } from "../lib/parsing";
@@ -231,7 +231,14 @@ opCodeMap[5] = {
   itxn_field: ITxnField,
   itxn_submit: ITxnSubmit,
   itxn: ITxn,
-  itxna: ITxna
+  itxna: ITxna,
+
+  // gtxn, other ops
+  txnas: Txnas,
+  gtxnas: Gtxnas,
+  gtxnsas: Gtxnsas,
+  args: Args,
+  log: Log
 };
 
 // list of opcodes that require one extra parameter than others: `interpreter`.
@@ -243,7 +250,7 @@ const interpreterReqList = new Set([
   "app_local_put", "app_global_put", "app_local_del", "app_global_del",
   "gtxns", "gtxnsa", "min_balance", "gload", "gloads", "callsub", "retsub",
   "gaid", "gaids", "loads", "stores", "itxn_begin", "itxn_field", "itxn_submit",
-  "itxn", "itxna"
+  "itxn", "itxna", "txnas", "gtxnas", "gtxnsas", "args", "log"
 ]);
 
 /**

--- a/packages/runtime/src/parser/parser.ts
+++ b/packages/runtime/src/parser/parser.ts
@@ -402,8 +402,14 @@ export function opcodeFromSentence (words: string[], counter: number, interprete
   return new opCodeMap[tealVersion][opCode](words, counter);
 }
 
-// verify max cost of TEAL code is within consensus parameters
-export function assertMaxCost (gas: number, mode: ExecutionMode): void {
+/**
+ * verify max cost of TEAL code is within consensus parameters
+ * @param gas total cost consumed by the TEAL code (can be dynamic or static)
+ * @param mode Execution mode - Signature (stateless) OR Application (stateful)
+ * @param maxPooledApplCost Since AVM 1.0, opcode cost for APPLICATION mode can be pooled accross
+ * multiple transactions. If passed, gas is evaluated against maxPooledApplCost
+ */
+export function assertMaxCost (gas: number, mode: ExecutionMode, maxPooledApplCost?: number): void {
   if (mode === ExecutionMode.SIGNATURE) {
     // check max cost (for stateless)
     if (gas > LogicSigMaxCost) {
@@ -414,7 +420,7 @@ export function assertMaxCost (gas: number, mode: ExecutionMode): void {
       });
     }
   } else {
-    if (gas > MaxAppProgramCost) {
+    if (gas > (maxPooledApplCost ?? MaxAppProgramCost)) {
       // check max cost (for stateful)
       throw new RuntimeError(RUNTIME_ERRORS.TEAL.MAX_COST_EXCEEDED, {
         cost: gas,

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -15,7 +15,7 @@ import { LogicSigAccount } from "./logicsig";
 import { mockSuggestedParams } from "./mock/tx";
 import {
   AccountAddress, AccountStoreI, AppDeploymentFlags, AppOptionalFlags,
-  ASADeploymentFlags, ASAInfo, AssetHoldingM, Context,
+  ASADeploymentFlags, ASAInfo, AssetHoldingM, BaseTxReceipt, Context,
   DeployedAppTxReceipt,
   DeployedAssetTxReceipt,
   ExecutionMode, RuntimeAccount, SSCAttributesM, SSCInfo, StackElem, State, Txn, TxReceipt
@@ -608,7 +608,7 @@ export class Runtime {
    * @param to to address
    * @param amount amount of algo in microalgos
    */
-  fundLsig (from: RuntimeAccount, to: AccountAddress, amount: number): void {
+  fundLsig (from: RuntimeAccount, to: AccountAddress, amount: number): TxReceipt {
     const fundParam: types.ExecParams = {
       type: types.TransactionType.TransferAlgo,
       sign: types.SignType.SecretKey,
@@ -617,7 +617,7 @@ export class Runtime {
       amountMicroAlgos: amount,
       payFlags: { totalFee: 1000 }
     };
-    this.executeTx(fundParam); /// /////////////////
+    return this.executeTx(fundParam) as TxReceipt;
   }
 
   /**

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -21,7 +21,7 @@ import {
   ASADeploymentFlags, ASAInfo, AssetHoldingM, BaseTxReceipt, Context,
   DeployedAppTxReceipt,
   DeployedAssetTxReceipt,
-  ExecutionMode, RuntimeAccount, SSCAttributesM, SSCInfo, StackElem, State, Txn, TxReceipt
+  EncTx, ExecutionMode, RuntimeAccount, SSCAttributesM, SSCInfo, StackElem, State, TxReceipt
 } from "./types";
 
 export class Runtime {
@@ -60,7 +60,7 @@ export class Runtime {
     this.loadedAssetsDefs = loadASAFile(this.store.accountNameAddress);
 
     // context for interpreter
-    this.ctx = new Ctx(cloneDeep(this.store), <Txn>{}, [], [], this);
+    this.ctx = new Ctx(cloneDeep(this.store), <EncTx>{}, [], [], this);
 
     this.round = 2;
     this.timestamp = 1;
@@ -146,7 +146,7 @@ export class Runtime {
    * Validate first and last rounds of transaction using current round
    * @param gtxns transactions
    */
-  validateTxRound (gtxns: Txn[]): void {
+  validateTxRound (gtxns: EncTx[]): void {
     // https://developer.algorand.org/docs/features/transactions/#current-round
     for (const txn of gtxns) {
       if (Number(txn.fv) >= this.round || txn.lv <= this.round) {
@@ -300,7 +300,7 @@ export class Runtime {
    * @param txnParams : Transaction parameters for current txn or txn Group
    * @returns: [current transaction, transaction group]
    */
-  createTxnContext (txnParams: types.ExecParams | types.ExecParams[]): [Txn, Txn[]] {
+  createTxnContext (txnParams: types.ExecParams | types.ExecParams[]): [EncTx, EncTx[]] {
     // if txnParams is array, then user is requesting for a group txn
     if (Array.isArray(txnParams)) {
       if (txnParams.length > 16) {
@@ -312,7 +312,7 @@ export class Runtime {
         const mockParams = mockSuggestedParams(txnParam.payFlags, this.round);
         const tx = webTx.mkTransaction(txnParam, mockParams);
         // convert to encoded obj for compatibility
-        const encodedTxnObj = tx.get_obj_for_encoding() as Txn;
+        const encodedTxnObj = tx.get_obj_for_encoding() as EncTx;
         encodedTxnObj.txID = tx.txID();
         txns.push(encodedTxnObj);
       }
@@ -322,7 +322,7 @@ export class Runtime {
       const mockParams = mockSuggestedParams(txnParams.payFlags, this.round);
       const tx = webTx.mkTransaction(txnParams, mockParams);
 
-      const encodedTxnObj = tx.get_obj_for_encoding() as Txn;
+      const encodedTxnObj = tx.get_obj_for_encoding() as EncTx;
       encodedTxnObj.txID = tx.txID();
       return [encodedTxnObj, [encodedTxnObj]];
     }

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -47,7 +47,7 @@ export class Runtime {
       appNameInfo: new Map<string, SSCInfo>(),
       appCounter: 0, // initialize app counter with 0
       assetCounter: 0, // initialize asset counter with 0
-      txnInfo: new Map<string, TxReceipt>() // receipt of each transaction, i.e map of {txID: txReceipt}
+      txReceipts: new Map<string, TxReceipt>() // receipt of each transaction, i.e map of {txID: txReceipt}
     };
 
     // intialize accounts (should be done during runtime initialization)
@@ -67,8 +67,8 @@ export class Runtime {
    * Returns transaction receipt for a particular transaction
    * @param txID transaction ID
    */
-  getTransactionInfo (txID: string): TxReceipt | undefined {
-    return this.store.txnInfo.get(txID);
+  getTxReceipt (txID: string): TxReceipt | undefined {
+    return this.store.txReceipts.get(txID);
   }
 
   /**
@@ -645,7 +645,7 @@ export class Runtime {
         throw new RuntimeError(RUNTIME_ERRORS.GENERAL.INVALID_PROGRAM);
       }
       this.run(program, ExecutionMode.SIGNATURE, 0, debugStack);
-      return this.ctx.state.txnInfo.get(this.ctx.tx.txID) as TxReceipt;
+      return this.ctx.state.txReceipts.get(this.ctx.tx.txID) as TxReceipt;
     } else {
       throw new RuntimeError(RUNTIME_ERRORS.GENERAL.LOGIC_SIGNATURE_NOT_FOUND);
     }
@@ -705,7 +705,7 @@ export class Runtime {
     indexInGroup: number, debugStack?: number): TxReceipt {
     const interpreter = new Interpreter();
     // set new tx receipt
-    this.ctx.state.txnInfo.set(this.ctx.tx.txID, {
+    this.ctx.state.txReceipts.set(this.ctx.tx.txID, {
       txn: this.ctx.tx,
       txID: this.ctx.tx.txID
     });
@@ -718,6 +718,6 @@ export class Runtime {
     if (executionMode === ExecutionMode.APPLICATION) {
       this.ctx.sharedScratchSpace.set(indexInGroup, interpreter.scratch);
     }
-    return this.ctx.state.txnInfo.get(this.ctx.tx.txID) as TxReceipt;
+    return this.ctx.state.txReceipts.get(this.ctx.tx.txID) as TxReceipt;
   }
 }

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -674,6 +674,9 @@ export class Runtime {
   run (program: string, executionMode: ExecutionMode, indexInGroup: number, debugStack?: number): void {
     const interpreter = new Interpreter();
     interpreter.execute(program, executionMode, this, debugStack);
+    // reset pooled opcode cost for single tx, this is to handle singular functions
+    // which don't "initialize" a new ctx (eg. addApp)
+    if (this.ctx.gtxs.length === 1) { this.ctx.pooledApplCost = 0; }
     if (executionMode === ExecutionMode.APPLICATION) {
       this.ctx.sharedScratchSpace.set(indexInGroup, interpreter.scratch);
     }

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -15,6 +15,8 @@ import { mockSuggestedParams } from "./mock/tx";
 import {
   AccountAddress, AccountStoreI, AppDeploymentFlags, AppOptionalFlags,
   ASADeploymentFlags, ASAInfo, AssetHoldingM, Context,
+  DeployedAppTxReceipt,
+  DeployedAssetTxReceipt,
   ExecutionMode, RuntimeAccount, SSCAttributesM, SSCInfo, StackElem, State, Txn, TxReceipt
 } from "./types";
 
@@ -352,7 +354,7 @@ export class Runtime {
    * @param name ASA name
    * @param flags ASA Deployment Flags
    */
-  addAsset (asa: string, flags: ASADeploymentFlags): TxReceipt {
+  addAsset (asa: string, flags: ASADeploymentFlags): DeployedAssetTxReceipt {
     const txReceipt = this.ctx.addAsset(asa, flags.creator.addr, flags);
     this.store = this.ctx.state;
 
@@ -365,7 +367,7 @@ export class Runtime {
    * @param name ASA name
    * @param flags ASA Deployment Flags
    */
-  addASADef (asa: string, asaDef: types.ASADef, flags: ASADeploymentFlags): TxReceipt {
+  addASADef (asa: string, asaDef: types.ASADef, flags: ASADeploymentFlags): DeployedAssetTxReceipt {
     const txReceipt = this.ctx.addASADef(asa, asaDef, flags.creator.addr, flags);
     this.store = this.ctx.state;
 
@@ -459,7 +461,7 @@ export class Runtime {
     flags: AppDeploymentFlags, payFlags: types.TxParams,
     approvalProgram: string, clearProgram: string,
     debugStack?: number
-  ): TxReceipt {
+  ): DeployedAppTxReceipt {
     this.addCtxAppCreateTxn(flags, payFlags);
     this.ctx.debugStack = debugStack;
     const txReceipt = this.ctx.addApp(flags.sender.addr, flags, approvalProgram, clearProgram, 0);

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -9,7 +9,7 @@ import { Ctx } from "./ctx";
 import { RUNTIME_ERRORS } from "./errors/errors-list";
 import { RuntimeError } from "./errors/runtime-errors";
 import { Interpreter, loadASAFile } from "./index";
-import { ALGORAND_ACCOUNT_MIN_BALANCE, ZERO_ADDRESS_STR } from "./lib/constants";
+import { ALGORAND_ACCOUNT_MIN_BALANCE, TransactionTypeEnum, ZERO_ADDRESS_STR } from "./lib/constants";
 import { convertToString } from "./lib/parsing";
 import { LogicSigAccount } from "./logicsig";
 import { mockSuggestedParams } from "./mock/tx";
@@ -348,7 +348,9 @@ export class Runtime {
       mockSuggestedParams(flags, this.round)
     );
 
-    if (this.ctx.tx === undefined || this.ctx.tx.type !== "acfg") { // could already be defined (if used as a txGroup in this.executeTx())
+    if (
+      this.ctx.tx === undefined || this.ctx.tx.type !== TransactionTypeEnum.ASSET_CONFIG
+    ) { // could already be defined (if used as a txGroup in this.executeTx())
       const encTx = { ...txn.get_obj_for_encoding(), txID: txn.txID() };
       this.ctx.tx = encTx;
       this.ctx.gtxs = [encTx];

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -15,7 +15,7 @@ import { mockSuggestedParams } from "./mock/tx";
 import {
   AccountAddress, AccountStoreI, AppDeploymentFlags, AppOptionalFlags,
   ASADeploymentFlags, ASAInfo, AssetHoldingM, Context,
-  ExecutionMode, RuntimeAccount, SSCAttributesM, SSCInfo, StackElem, State, Txn
+  ExecutionMode, RuntimeAccount, SSCAttributesM, SSCInfo, StackElem, State, Txn, TxReceipt
 } from "./types";
 
 export class Runtime {
@@ -43,7 +43,8 @@ export class Runtime {
       assetNameInfo: new Map<string, ASAInfo>(),
       appNameInfo: new Map<string, SSCInfo>(),
       appCounter: 0, // initialize app counter with 0
-      assetCounter: 0 // initialize asset counter with 0
+      assetCounter: 0, // initialize asset counter with 0
+      txnInfo: new Map<string, TxReceipt>() // receipt of each transaction, i.e map of {txID: txReceipt}
     };
 
     // intialize accounts (should be done during runtime initialization)
@@ -57,6 +58,14 @@ export class Runtime {
 
     this.round = 2;
     this.timestamp = 1;
+  }
+
+  /**
+   * Returns transaction receipt for a particular transaction
+   * @param txID transaction ID
+   */
+  getTransactionInfo (txID: string): TxReceipt | undefined {
+    return this.store.txnInfo.get(txID);
   }
 
   /**
@@ -312,7 +321,7 @@ export class Runtime {
   mkAssetCreateTx (
     name: string, flags: ASADeploymentFlags, asaDef: modelsv2.AssetParams): void {
     // this funtion is called only for validation of parameters passed
-    algosdk.makeAssetCreateTxnWithSuggestedParams(
+    const txn = algosdk.makeAssetCreateTxnWithSuggestedParams(
       flags.creator.addr,
       webTx.encodeNote(flags.note, flags.noteb64),
       asaDef.total,
@@ -330,6 +339,12 @@ export class Runtime {
         : asaDef.metadataHash,
       mockSuggestedParams(flags, this.round)
     );
+
+    if (this.ctx.tx === undefined || this.ctx.tx.type !== "acfg") { // could already be defined (if used as a txGroup in this.executeTx())
+      const encTx = { ...txn.get_obj_for_encoding(), txID: txn.txID() };
+      this.ctx.tx = encTx;
+      this.ctx.gtxs = [encTx];
+    }
   }
 
   /**
@@ -337,12 +352,12 @@ export class Runtime {
    * @param name ASA name
    * @param flags ASA Deployment Flags
    */
-  addAsset (asa: string, flags: ASADeploymentFlags): number {
-    this.ctx.addAsset(asa, flags.creator.addr, flags);
+  addAsset (asa: string, flags: ASADeploymentFlags): TxReceipt {
+    const txReceipt = this.ctx.addAsset(asa, flags.creator.addr, flags);
     this.store = this.ctx.state;
 
     this.optInToASAMultiple(this.store.assetCounter, this.loadedAssetsDefs[asa].optInAccNames);
-    return this.store.assetCounter;
+    return txReceipt;
   }
 
   /**
@@ -350,12 +365,12 @@ export class Runtime {
    * @param name ASA name
    * @param flags ASA Deployment Flags
    */
-  addASADef (asa: string, asaDef: types.ASADef, flags: ASADeploymentFlags): number {
-    this.ctx.addASADef(asa, asaDef, flags.creator.addr, flags);
+  addASADef (asa: string, asaDef: types.ASADef, flags: ASADeploymentFlags): TxReceipt {
+    const txReceipt = this.ctx.addASADef(asa, asaDef, flags.creator.addr, flags);
     this.store = this.ctx.state;
 
     this.optInToASAMultiple(this.store.assetCounter, asaDef.optInAccNames);
-    return this.store.assetCounter;
+    return txReceipt;
   }
 
   /**
@@ -381,10 +396,11 @@ export class Runtime {
    * @param address Account address to opt-into asset
    * @param flags Transaction Parameters
    */
-  optIntoASA (assetIndex: number, address: AccountAddress, flags: types.TxParams): void {
-    this.ctx.optIntoASA(assetIndex, address, flags);
+  optIntoASA (assetIndex: number, address: AccountAddress, flags: types.TxParams): TxReceipt {
+    const txReceipt = this.ctx.optIntoASA(assetIndex, address, flags);
 
     this.store = this.ctx.state;
+    return txReceipt;
   }
 
   /**
@@ -443,13 +459,13 @@ export class Runtime {
     flags: AppDeploymentFlags, payFlags: types.TxParams,
     approvalProgram: string, clearProgram: string,
     debugStack?: number
-  ): number {
+  ): TxReceipt {
     this.addCtxAppCreateTxn(flags, payFlags);
     this.ctx.debugStack = debugStack;
-    this.ctx.addApp(flags.sender.addr, flags, approvalProgram, clearProgram, 0);
+    const txReceipt = this.ctx.addApp(flags.sender.addr, flags, approvalProgram, clearProgram, 0);
 
     this.store = this.ctx.state;
-    return this.store.appCounter;
+    return txReceipt;
   }
 
   // creates new OptIn transaction object and update context
@@ -485,12 +501,13 @@ export class Runtime {
    * each opcode execution (upto depth = debugStack)
    */
   optInToApp (accountAddr: string, appID: number,
-    flags: AppOptionalFlags, payFlags: types.TxParams, debugStack?: number): void {
+    flags: AppOptionalFlags, payFlags: types.TxParams, debugStack?: number): TxReceipt {
     this.addCtxOptInTx(accountAddr, appID, payFlags, flags);
     this.ctx.debugStack = debugStack;
-    this.ctx.optInToApp(accountAddr, appID, 0);
+    const txReceipt = this.ctx.optInToApp(accountAddr, appID, 0);
 
     this.store = this.ctx.state;
+    return txReceipt;
   }
 
   // creates new Update transaction object and update context
@@ -538,13 +555,14 @@ export class Runtime {
     payFlags: types.TxParams,
     flags: AppOptionalFlags,
     debugStack?: number
-  ): void {
+  ): TxReceipt {
     this.addCtxAppUpdateTx(senderAddr, appID, payFlags, flags);
     this.ctx.debugStack = debugStack;
-    this.ctx.updateApp(appID, approvalProgram, clearProgram, 0);
+    const txReceipt = this.ctx.updateApp(appID, approvalProgram, clearProgram, 0);
 
     // If successful, Update programs and state
     this.store = this.ctx.state;
+    return txReceipt;
   }
 
   // verify 'amt' microalgos can be withdrawn from account
@@ -591,7 +609,7 @@ export class Runtime {
       amountMicroAlgos: amount,
       payFlags: { totalFee: 1000 }
     };
-    this.executeTx(fundParam);
+    this.executeTx(fundParam); /// /////////////////
   }
 
   /**
@@ -600,7 +618,7 @@ export class Runtime {
    * @param debugStack: if passed then TEAL Stack is logged to console after
    * each opcode execution (upto depth = debugStack)
    */
-  validateLsigAndRun (txnParam: types.ExecParams, debugStack?: number): void {
+  validateLsigAndRun (txnParam: types.ExecParams, debugStack?: number): TxReceipt {
     // check if transaction is signed by logic signature,
     // if yes verify signature and run logic
     if (txnParam.sign === types.SignType.LogicSignature && txnParam.lsig) {
@@ -619,6 +637,7 @@ export class Runtime {
         throw new RuntimeError(RUNTIME_ERRORS.GENERAL.INVALID_PROGRAM);
       }
       this.run(program, ExecutionMode.SIGNATURE, 0, debugStack);
+      return this.ctx.state.txnInfo.get(this.ctx.tx.txID) as TxReceipt;
     } else {
       throw new RuntimeError(RUNTIME_ERRORS.GENERAL.LOGIC_SIGNATURE_NOT_FOUND);
     }
@@ -631,7 +650,7 @@ export class Runtime {
    * @param debugStack: if passed then TEAL Stack is logged to console after
    * each opcode execution (upto depth = debugStack)
    */
-  executeTx (txnParams: types.ExecParams | types.ExecParams[], debugStack?: number): void {
+  executeTx (txnParams: types.ExecParams | types.ExecParams[], debugStack?: number): TxReceipt | TxReceipt[] {
     const txnParameters = Array.isArray(txnParams) ? txnParams : [txnParams];
     for (const txn of txnParameters) {
       switch (txn.type) {
@@ -657,10 +676,13 @@ export class Runtime {
 
     // Run TEAL program associated with each transaction and
     // then execute the transaction without interacting with store.
-    this.ctx.processTransactions(txnParameters);
+    const txReceipts = this.ctx.processTransactions(txnParameters);
 
     // update store only if all the transactions are passed
     this.store = this.ctx.state;
+
+    // return transaction receipt(s)
+    return Array.isArray(txnParams) ? txReceipts : txReceipts[0];
   }
 
   /**
@@ -671,14 +693,23 @@ export class Runtime {
    * each opcode execution (upto depth = debugStack)
    * NOTE: Application mode is only supported in TEALv > 1
    */
-  run (program: string, executionMode: ExecutionMode, indexInGroup: number, debugStack?: number): void {
+  run (program: string, executionMode: ExecutionMode,
+    indexInGroup: number, debugStack?: number): TxReceipt {
     const interpreter = new Interpreter();
-    interpreter.execute(program, executionMode, this, debugStack);
+    // set new tx receipt
+    this.ctx.state.txnInfo.set(this.ctx.tx.txID, {
+      txn: this.ctx.tx,
+      txID: this.ctx.tx.txID
+    });
+
     // reset pooled opcode cost for single tx, this is to handle singular functions
     // which don't "initialize" a new ctx (eg. addApp)
     if (this.ctx.gtxs.length === 1) { this.ctx.pooledApplCost = 0; }
+    interpreter.execute(program, executionMode, this, debugStack);
+
     if (executionMode === ExecutionMode.APPLICATION) {
       this.ctx.sharedScratchSpace.set(indexInGroup, interpreter.scratch);
     }
+    return this.ctx.state.txnInfo.get(this.ctx.tx.txID) as TxReceipt;
   }
 }

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -109,6 +109,7 @@ export interface Context {
   gtxs: Txn[] // all transactions
   args?: Uint8Array[]
   debugStack?: number //  max number of top elements from the stack to print after each opcode execution.
+  pooledApplCost: number // total opcode cost for each application call for single/group tx
   // inner transaction props
   isInnerTx: boolean // true if "ctx" is switched to an inner transaction
   createdAssetID: number // Asset ID allocated by the creation of an ASA (for an inner-tx)

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -69,15 +69,22 @@ export interface AccountsMap {
  * (where we use maps instead of arrays in sdk structures). */
 export type RuntimeAccountMap = Map<string, AccountAddress>;
 
-export interface TxReceipt {
+export interface BaseTxReceipt {
   txn: Txn
   txID: string
   gas?: number
   logs?: string[]
-  // returned during time of creation of asset/app
-  assetID?: number
-  appID?: number
 }
+
+export interface DeployedAssetTxReceipt extends BaseTxReceipt {
+  assetID: number
+}
+
+export interface DeployedAppTxReceipt extends BaseTxReceipt {
+  appID: number
+}
+
+export type TxReceipt = BaseTxReceipt | DeployedAppTxReceipt | DeployedAssetTxReceipt;
 
 export interface State {
   accounts: Map<string, AccountStoreI>
@@ -142,17 +149,17 @@ export interface Context {
   closeApp: (sender: AccountAddress, appID: number) => void
   processTransactions: (txnParams: types.ExecParams[]) => TxReceipt[]
   addAsset: (name: string,
-    fromAccountAddr: AccountAddress, flags: ASADeploymentFlags) => TxReceipt
+    fromAccountAddr: AccountAddress, flags: ASADeploymentFlags) => DeployedAssetTxReceipt
   addASADef: (
     name: string, asaDef: types.ASADef,
     fromAccountAddr: AccountAddress, flags: ASADeploymentFlags
-  ) => TxReceipt
+  ) => DeployedAssetTxReceipt
   optIntoASA: (
     assetIndex: number, address: AccountAddress, flags: types.TxParams) => TxReceipt
   addApp: (
     fromAccountAddr: string, flags: AppDeploymentFlags,
     approvalProgram: string, clearProgram: string, idx: number
-  ) => TxReceipt
+  ) => DeployedAppTxReceipt
   optInToApp: (accountAddr: string, appID: number, idx: number) => TxReceipt
   updateApp: (appID: number, approvalProgram: string, clearProgram: string, idx: number) => TxReceipt
 }

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -95,7 +95,7 @@ export interface State {
   appNameInfo: Map<string, SSCInfo>
   appCounter: number
   assetCounter: number
-  txnInfo: Map<string, TxReceipt> // map of {txID: txReceipt}
+  txReceipts: Map<string, TxReceipt> // map of {txID: txReceipt}
 }
 
 export interface DeployedAssetInfo {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -69,6 +69,16 @@ export interface AccountsMap {
  * (where we use maps instead of arrays in sdk structures). */
 export type RuntimeAccountMap = Map<string, AccountAddress>;
 
+export interface TxReceipt {
+  txn: Txn
+  txID: string
+  gas?: number
+  logs?: string[]
+  // returned during time of creation of asset/app
+  assetID?: number
+  appID?: number
+}
+
 export interface State {
   accounts: Map<string, AccountStoreI>
   accountNameAddress: Map<string, AccountAddress>
@@ -78,6 +88,7 @@ export interface State {
   appNameInfo: Map<string, SSCInfo>
   appCounter: number
   assetCounter: number
+  txnInfo: Map<string, TxReceipt> // map of {txID: txReceipt}
 }
 
 export interface DeployedAssetInfo {
@@ -129,21 +140,21 @@ export interface Context {
   destroyAsset: (assetId: number) => void
   deleteApp: (appID: number) => void
   closeApp: (sender: AccountAddress, appID: number) => void
-  processTransactions: (txnParams: types.ExecParams[]) => void
+  processTransactions: (txnParams: types.ExecParams[]) => TxReceipt[]
   addAsset: (name: string,
-    fromAccountAddr: AccountAddress, flags: ASADeploymentFlags) => number
+    fromAccountAddr: AccountAddress, flags: ASADeploymentFlags) => TxReceipt
   addASADef: (
     name: string, asaDef: types.ASADef,
     fromAccountAddr: AccountAddress, flags: ASADeploymentFlags
-  ) => number
+  ) => TxReceipt
   optIntoASA: (
-    assetIndex: number, address: AccountAddress, flags: types.TxParams) => void
+    assetIndex: number, address: AccountAddress, flags: types.TxParams) => TxReceipt
   addApp: (
     fromAccountAddr: string, flags: AppDeploymentFlags,
     approvalProgram: string, clearProgram: string, idx: number
-  ) => number
-  optInToApp: (accountAddr: string, appID: number, idx: number) => void
-  updateApp: (appID: number, approvalProgram: string, clearProgram: string, idx: number) => void
+  ) => TxReceipt
+  optInToApp: (accountAddr: string, appID: number, idx: number) => TxReceipt
+  updateApp: (appID: number, approvalProgram: string, clearProgram: string, idx: number) => TxReceipt
 }
 
 // custom AssetHolding for AccountStore (using bigint in amount instead of number)

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -21,7 +21,7 @@ export type AppArgs = Array<string | number>;
 export type StackElem = bigint | Uint8Array;
 export type TEALStack = IStack<bigint | Uint8Array>;
 
-export interface Txn extends EncodedTransaction {
+export interface EncTx extends EncodedTransaction {
   txID: string
 }
 
@@ -70,7 +70,7 @@ export interface AccountsMap {
 export type RuntimeAccountMap = Map<string, AccountAddress>;
 
 export interface BaseTxReceipt {
-  txn: Txn
+  txn: EncTx
   txID: string
   gas?: number
   logs?: string[]
@@ -123,8 +123,8 @@ export interface Context {
   state: State
   sharedScratchSpace: Map<number, StackElem[]>
   knowableID: Map<number, ID>
-  tx: Txn // current txn
-  gtxs: Txn[] // all transactions
+  tx: EncTx // current txn
+  gtxs: EncTx[] // all transactions
   args?: Uint8Array[]
   debugStack?: number //  max number of top elements from the stack to print after each opcode execution.
   pooledApplCost: number // total opcode cost for each application call for single/group tx
@@ -236,7 +236,7 @@ export interface AccountStoreI {
 
 /**
  * https://developer.algorand.org/docs/reference/teal/specification/#oncomplete */
-export enum TxnOnComplete {
+export enum TxOnComplete {
   NoOp = '0',
   OptIn = '1',
   CloseOut = '2',

--- a/packages/runtime/test/fixtures/stateful/assets/pooled-opcode-budget.teal
+++ b/packages/runtime/test/fixtures/stateful/assets/pooled-opcode-budget.teal
@@ -1,0 +1,42 @@
+#pragma version 5
+
+int 0
+txn ApplicationID
+==
+bnz accept
+
+int OptIn
+txn OnCompletion
+==
+bnz accept
+
+// cost of this branch is very high
+txna ApplicationArgs 0
+byte "exceeded_cost"
+==
+bnz exceeded_cost
+
+// cost of this branch is very low
+txna ApplicationArgs 0
+byte "normal_cost"
+==
+bnz accept
+
+exceeded_cost:
+byte base64 iZWMx72KvU6Bw6sPAWQFL96YH+VMrBA0XKWD9XbZOZI=
+byte base64 if8ooA+32YZc4SQBvIDDY8tgTatPoq4IZ8Kr+We1t38LR2RuURmaVu9D4shbi4VvND87PUqq5/0vsNFEGIIEDA==
+addr 7JOPVEP3ABJUW5YZ5WFIONLPWTZ5MYX5HFK4K7JLGSIAG7RRB42MNLQ224
+// costs about 1900
+ed25519verify
+byte base64 iZWMx72KvU6Bw6sPAWQFL96YH+VMrBA0XKWD9XbZOZI=
+byte base64 if8ooA+32YZc4SQBvIDDY8tgTatPoq4IZ8Kr+We1t38LR2RuURmaVu9D4shbi4VvND87PUqq5/0vsNFEGIIEDA==
+addr 7JOPVEP3ABJUW5YZ5WFIONLPWTZ5MYX5HFK4K7JLGSIAG7RRB42MNLQ224
+// costs about 1900
+ed25519verify
+byte "hello"
+// costs about 130
+keccak256
+
+accept:
+int 1
+return

--- a/packages/runtime/test/integration/app-optin.ts
+++ b/packages/runtime/test/integration/app-optin.ts
@@ -36,7 +36,7 @@ describe("Algorand Smart Contracts - Stateful Counter example", function () {
   it("should opt-in to app successfully and update local state", function () {
     // create new app
     approvalProgram = getProgram('accept-optin.teal');
-    appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram).appID as number;
+    appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram).appID;
 
     // opt-in (should be accepted)
     assert.doesNotThrow(() => runtime.optInToApp(john.address, appID, {}, {}));
@@ -50,7 +50,7 @@ describe("Algorand Smart Contracts - Stateful Counter example", function () {
   it("should reject opt-in to app", function () {
     // create new app
     approvalProgram = getProgram('reject-optin.teal');
-    appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram).appID as number;
+    appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram).appID;
 
     // verify local state not present BEFORE optin
     assert.isUndefined(alice.appsLocalState.get(appID));

--- a/packages/runtime/test/integration/app-optin.ts
+++ b/packages/runtime/test/integration/app-optin.ts
@@ -36,7 +36,7 @@ describe("Algorand Smart Contracts - Stateful Counter example", function () {
   it("should opt-in to app successfully and update local state", function () {
     // create new app
     approvalProgram = getProgram('accept-optin.teal');
-    appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram);
+    appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram).appID as number;
 
     // opt-in (should be accepted)
     assert.doesNotThrow(() => runtime.optInToApp(john.address, appID, {}, {}));
@@ -50,7 +50,7 @@ describe("Algorand Smart Contracts - Stateful Counter example", function () {
   it("should reject opt-in to app", function () {
     // create new app
     approvalProgram = getProgram('reject-optin.teal');
-    appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram);
+    appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram).appID as number;
 
     // verify local state not present BEFORE optin
     assert.isUndefined(alice.appsLocalState.get(appID));

--- a/packages/runtime/test/integration/app-update.ts
+++ b/packages/runtime/test/integration/app-update.ts
@@ -32,7 +32,7 @@ describe("App Update Test", function () {
       localInts: 5
     };
 
-    appID = runtime.addApp(flags, {}, approvalProgram, clearProgram);
+    appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number;
 
     groupTx = [
       {

--- a/packages/runtime/test/integration/app-update.ts
+++ b/packages/runtime/test/integration/app-update.ts
@@ -32,7 +32,7 @@ describe("App Update Test", function () {
       localInts: 5
     };
 
-    appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number;
+    appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID;
 
     groupTx = [
       {

--- a/packages/runtime/test/integration/atomic-transfer.ts
+++ b/packages/runtime/test/integration/atomic-transfer.ts
@@ -25,7 +25,7 @@ describe("Algorand Smart Contracts - Atomic Transfers", function () {
     runtime = new Runtime([john, alice]); // setup test
     // create asset
     assetId = runtime.addAsset('gold',
-      { creator: { ...john.account, name: "john" } }).assetID as number;
+      { creator: { ...john.account, name: "john" } }).assetID;
     approvalProgram = getProgram('counter-approval.teal');
     clearProgram = getProgram('clear.teal');
 
@@ -36,7 +36,7 @@ describe("Algorand Smart Contracts - Atomic Transfers", function () {
       globalInts: 32,
       localBytes: 8,
       localInts: 8
-    }, {}, approvalProgram, clearProgram).appID as number;
+    }, {}, approvalProgram, clearProgram).appID;
     // opt-in to app
     runtime.optInToApp(john.address, appID, {}, {});
     // opt-in for alice

--- a/packages/runtime/test/integration/atomic-transfer.ts
+++ b/packages/runtime/test/integration/atomic-transfer.ts
@@ -25,7 +25,7 @@ describe("Algorand Smart Contracts - Atomic Transfers", function () {
     runtime = new Runtime([john, alice]); // setup test
     // create asset
     assetId = runtime.addAsset('gold',
-      { creator: { ...john.account, name: "john" } });
+      { creator: { ...john.account, name: "john" } }).assetID as number;
     approvalProgram = getProgram('counter-approval.teal');
     clearProgram = getProgram('clear.teal');
 
@@ -36,7 +36,7 @@ describe("Algorand Smart Contracts - Atomic Transfers", function () {
       globalInts: 32,
       localBytes: 8,
       localInts: 8
-    }, {}, approvalProgram, clearProgram);
+    }, {}, approvalProgram, clearProgram).appID as number;
     // opt-in to app
     runtime.optInToApp(john.address, appID, {}, {});
     // opt-in for alice

--- a/packages/runtime/test/integration/basic-teal.ts
+++ b/packages/runtime/test/integration/basic-teal.ts
@@ -19,14 +19,14 @@ describe("Stateless Algorand Smart Contracts delegated signature mode", function
   let john: AccountStore;
   let bob: AccountStore;
   let runtime: Runtime;
-  let txnParams: types.AlgoTransferParam;
+  let txParams: types.AlgoTransferParam;
 
   this.beforeAll(async function () {
     john = new AccountStore(initialJohnHolding);
     bob = new AccountStore(initialBobHolding);
     runtime = new Runtime([john, bob]);
 
-    txnParams = {
+    txParams = {
       type: types.TransactionType.TransferAlgo, // payment
       sign: types.SignType.LogicSignature,
       fromAccountAddr: john.account.addr,
@@ -53,7 +53,7 @@ describe("Stateless Algorand Smart Contracts delegated signature mode", function
     lsig.sign(john.account.sk);
 
     runtime.executeTx({
-      ...txnParams,
+      ...txParams,
       sign: types.SignType.LogicSignature,
       fromAccountAddr: john.address,
       lsig: lsig
@@ -71,7 +71,7 @@ describe("Stateless Algorand Smart Contracts delegated signature mode", function
     lsig.sign(john.account.sk);
 
     const invalidParam = {
-      ...txnParams,
+      ...txParams,
       lsig: lsig,
       amountMicroAlgos: 50n
     };

--- a/packages/runtime/test/integration/close-clear-ssc.ts
+++ b/packages/runtime/test/integration/close-clear-ssc.ts
@@ -54,7 +54,7 @@ describe("ASC - CloseOut from Application and Clear State", function () {
   });
 
   it("should successfully closeOut from app and update state according to asc", function () {
-    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram); // create app
+    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number; // create app
     const initialJohnMinBalance = runtime.getAccount(john.address).minBalance;
 
     runtime.optInToApp(john.address, appID, {}, {}); // opt-in to app (set new local state)
@@ -88,7 +88,7 @@ describe("ASC - CloseOut from Application and Clear State", function () {
 
   it("should throw error if user is not opted-in for closeOut call", function () {
     // create app
-    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram);
+    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number;
     closeOutParams.appID = appID;
 
     expectRuntimeError(
@@ -99,7 +99,7 @@ describe("ASC - CloseOut from Application and Clear State", function () {
   });
 
   it("should not delete application on CloseOut call if logic is rejected", function () {
-    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram);
+    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number;
     const initialJohnMinBalance = runtime.getAccount(john.address).minBalance;
     runtime.optInToApp(john.address, appID, {}, {}); // opt-in to app (set new local state)
     syncAccount();
@@ -134,7 +134,7 @@ describe("ASC - CloseOut from Application and Clear State", function () {
   it("should delete application on clearState call even if logic is rejected", function () {
     // create app
     const rejectClearProgram = getProgram('rejectClear.teal');
-    const appID = runtime.addApp(flags, {}, approvalProgram, rejectClearProgram);
+    const appID = runtime.addApp(flags, {}, approvalProgram, rejectClearProgram).appID as number;
     const initialJohnMinBalance = runtime.getAccount(john.address).minBalance;
     const clearAppParams: types.AppCallsParam = {
       type: types.TransactionType.ClearApp,

--- a/packages/runtime/test/integration/close-clear-ssc.ts
+++ b/packages/runtime/test/integration/close-clear-ssc.ts
@@ -54,7 +54,7 @@ describe("ASC - CloseOut from Application and Clear State", function () {
   });
 
   it("should successfully closeOut from app and update state according to asc", function () {
-    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number; // create app
+    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID; // create app
     const initialJohnMinBalance = runtime.getAccount(john.address).minBalance;
 
     runtime.optInToApp(john.address, appID, {}, {}); // opt-in to app (set new local state)
@@ -88,7 +88,7 @@ describe("ASC - CloseOut from Application and Clear State", function () {
 
   it("should throw error if user is not opted-in for closeOut call", function () {
     // create app
-    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number;
+    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID;
     closeOutParams.appID = appID;
 
     expectRuntimeError(
@@ -99,7 +99,7 @@ describe("ASC - CloseOut from Application and Clear State", function () {
   });
 
   it("should not delete application on CloseOut call if logic is rejected", function () {
-    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number;
+    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID;
     const initialJohnMinBalance = runtime.getAccount(john.address).minBalance;
     runtime.optInToApp(john.address, appID, {}, {}); // opt-in to app (set new local state)
     syncAccount();
@@ -134,7 +134,7 @@ describe("ASC - CloseOut from Application and Clear State", function () {
   it("should delete application on clearState call even if logic is rejected", function () {
     // create app
     const rejectClearProgram = getProgram('rejectClear.teal');
-    const appID = runtime.addApp(flags, {}, approvalProgram, rejectClearProgram).appID as number;
+    const appID = runtime.addApp(flags, {}, approvalProgram, rejectClearProgram).appID;
     const initialJohnMinBalance = runtime.getAccount(john.address).minBalance;
     const clearAppParams: types.AppCallsParam = {
       type: types.TransactionType.ClearApp,

--- a/packages/runtime/test/integration/crowdfunding.ts
+++ b/packages/runtime/test/integration/crowdfunding.ts
@@ -63,7 +63,7 @@ describe("Crowdfunding basic tests", function () {
 
     const johnMinBalance = john.minBalance;
     const appID = runtime.addApp(
-      { ...validFlags, appArgs: appArgs }, {}, approvalProgram, clearProgram);
+      { ...validFlags, appArgs: appArgs }, {}, approvalProgram, clearProgram).appID as number;
     // verify sender's min balance increased after creating application
     assert.isAbove(runtime.getAccount(john.address).minBalance, johnMinBalance);
 

--- a/packages/runtime/test/integration/crowdfunding.ts
+++ b/packages/runtime/test/integration/crowdfunding.ts
@@ -63,7 +63,7 @@ describe("Crowdfunding basic tests", function () {
 
     const johnMinBalance = john.minBalance;
     const appID = runtime.addApp(
-      { ...validFlags, appArgs: appArgs }, {}, approvalProgram, clearProgram).appID as number;
+      { ...validFlags, appArgs: appArgs }, {}, approvalProgram, clearProgram).appID;
     // verify sender's min balance increased after creating application
     assert.isAbove(runtime.getAccount(john.address).minBalance, johnMinBalance);
 

--- a/packages/runtime/test/integration/deleteApp.ts
+++ b/packages/runtime/test/integration/deleteApp.ts
@@ -49,7 +49,7 @@ describe("Algorand Smart Contracts - Delete Application", function () {
 
   it("should delete application", function () {
     const initialMinBalance = john.minBalance;
-    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number;
+    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID;
     assert.equal(runtime.getAccount(john.address).minBalance,
       initialMinBalance + (APPLICATION_BASE_FEE + ((25000 + 3500) * 2 + (25000 + 25000) * 2)));
 
@@ -66,7 +66,7 @@ describe("Algorand Smart Contracts - Delete Application", function () {
 
   it("should not delete application if logic is rejected", function () {
     const initialMinBalance = john.minBalance;
-    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number; // create app
+    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID; // create app
 
     const minBalanceAfterAddApp = runtime.getAccount(john.address).minBalance;
     assert.equal(minBalanceAfterAddApp,

--- a/packages/runtime/test/integration/deleteApp.ts
+++ b/packages/runtime/test/integration/deleteApp.ts
@@ -49,7 +49,7 @@ describe("Algorand Smart Contracts - Delete Application", function () {
 
   it("should delete application", function () {
     const initialMinBalance = john.minBalance;
-    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram);
+    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number;
     assert.equal(runtime.getAccount(john.address).minBalance,
       initialMinBalance + (APPLICATION_BASE_FEE + ((25000 + 3500) * 2 + (25000 + 25000) * 2)));
 
@@ -66,7 +66,7 @@ describe("Algorand Smart Contracts - Delete Application", function () {
 
   it("should not delete application if logic is rejected", function () {
     const initialMinBalance = john.minBalance;
-    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram); // create app
+    const appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number; // create app
 
     const minBalanceAfterAddApp = runtime.getAccount(john.address).minBalance;
     assert.equal(minBalanceAfterAddApp,

--- a/packages/runtime/test/integration/deploy-app.ts
+++ b/packages/runtime/test/integration/deploy-app.ts
@@ -36,8 +36,8 @@ describe("Algorand Smart Contracts - Stateful Contract Account", function () {
 
   it("initialize new account for deployed app(s)", function () {
     // create new app
-    const appIdX = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram).appID as number;
-    const appIdY = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram).appID as number;
+    const appIdX = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram).appID;
+    const appIdY = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram).appID;
 
     assert.isDefined(runtime.getApp(appIdX));
     assert.isDefined(runtime.getApp(appIdY));

--- a/packages/runtime/test/integration/deploy-app.ts
+++ b/packages/runtime/test/integration/deploy-app.ts
@@ -36,8 +36,8 @@ describe("Algorand Smart Contracts - Stateful Contract Account", function () {
 
   it("initialize new account for deployed app(s)", function () {
     // create new app
-    const appIdX = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram);
-    const appIdY = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram);
+    const appIdX = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram).appID as number;
+    const appIdY = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram).appID as number;
 
     assert.isDefined(runtime.getApp(appIdX));
     assert.isDefined(runtime.getApp(appIdY));

--- a/packages/runtime/test/integration/deploy-asa.ts
+++ b/packages/runtime/test/integration/deploy-asa.ts
@@ -28,7 +28,7 @@ describe("Deploy ASA with mutiple opt-in accounts", function () {
 
   it("Should opt-in to multiple accounts mentioned in asa.yaml", () => {
     const asset =
-      runtime.addAsset('asa', { creator: { ...john.account, name: "john" } }).assetID as number;
+      runtime.addAsset('asa', { creator: { ...john.account, name: "john" } }).assetID;
 
     syncAccounts();
     assert.isDefined(bob.getAssetHolding(asset));

--- a/packages/runtime/test/integration/deploy-asa.ts
+++ b/packages/runtime/test/integration/deploy-asa.ts
@@ -27,7 +27,8 @@ describe("Deploy ASA with mutiple opt-in accounts", function () {
   }
 
   it("Should opt-in to multiple accounts mentioned in asa.yaml", () => {
-    const asset = runtime.addAsset('asa', { creator: { ...john.account, name: "john" } });
+    const asset =
+      runtime.addAsset('asa', { creator: { ...john.account, name: "john" } }).assetID as number;
 
     syncAccounts();
     assert.isDefined(bob.getAssetHolding(asset));

--- a/packages/runtime/test/integration/execute-transaction.ts
+++ b/packages/runtime/test/integration/execute-transaction.ts
@@ -34,7 +34,7 @@ describe("Algorand Smart Contracts - Execute transaction", function () {
   function setupAsset (): void {
     // create asset
     assetId = runtime.addAsset('gold',
-      { creator: { ...john.account, name: "john" } });
+      { creator: { ...john.account, name: "john" } }).assetID as number;
   }
 
   function setupApp (): void {

--- a/packages/runtime/test/integration/execute-transaction.ts
+++ b/packages/runtime/test/integration/execute-transaction.ts
@@ -34,7 +34,7 @@ describe("Algorand Smart Contracts - Execute transaction", function () {
   function setupAsset (): void {
     // create asset
     assetId = runtime.addAsset('gold',
-      { creator: { ...john.account, name: "john" } }).assetID as number;
+      { creator: { ...john.account, name: "john" } }).assetID;
   }
 
   function setupApp (): void {

--- a/packages/runtime/test/integration/group-index.ts
+++ b/packages/runtime/test/integration/group-index.ts
@@ -38,11 +38,11 @@ describe('Current Transaction Tests', function () {
 
     // create first application
     applicationId1 = runtime.addApp(
-      { ...creationFlags, sender: creator.account }, {}, approvalProgram, clearProgram).appID as number;
+      { ...creationFlags, sender: creator.account }, {}, approvalProgram, clearProgram).appID;
 
     // create second application
     applicationId2 = runtime.addApp(
-      { ...creationFlags, sender: creator.account }, {}, getProgram('test2.teal'), clearProgram).appID as number;
+      { ...creationFlags, sender: creator.account }, {}, getProgram('test2.teal'), clearProgram).appID;
   }
 
   it('Group Index Check', () => {

--- a/packages/runtime/test/integration/group-index.ts
+++ b/packages/runtime/test/integration/group-index.ts
@@ -38,11 +38,11 @@ describe('Current Transaction Tests', function () {
 
     // create first application
     applicationId1 = runtime.addApp(
-      { ...creationFlags, sender: creator.account }, {}, approvalProgram, clearProgram);
+      { ...creationFlags, sender: creator.account }, {}, approvalProgram, clearProgram).appID as number;
 
     // create second application
     applicationId2 = runtime.addApp(
-      { ...creationFlags, sender: creator.account }, {}, getProgram('test2.teal'), clearProgram);
+      { ...creationFlags, sender: creator.account }, {}, getProgram('test2.teal'), clearProgram).appID as number;
   }
 
   it('Group Index Check', () => {

--- a/packages/runtime/test/integration/inner-transaction/asset-tx.ts
+++ b/packages/runtime/test/integration/inner-transaction/asset-tx.ts
@@ -43,12 +43,12 @@ describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[Asset Transfer, 
   this.beforeEach(() => {
     // reset app (delete + create)
     john.createdApps.delete(appID);
-    appID = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram);
+    appID = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram).appID as number;
     appAccount = runtime.getAccount(getApplicationAddress(appID)); // update app account
 
     // create asset
     assetID = runtime.addAsset('gold',
-      { creator: { ...john.account, name: "john" } });
+      { creator: { ...john.account, name: "john" } }).assetID as number;
 
     // fund app (escrow belonging to app) with 10 ALGO
     const fundAppParams: types.AlgoTransferParam = {

--- a/packages/runtime/test/integration/inner-transaction/asset-tx.ts
+++ b/packages/runtime/test/integration/inner-transaction/asset-tx.ts
@@ -9,7 +9,7 @@ import { AccountStoreI, AppDeploymentFlags } from "../../../src/types";
 import { getProgram } from "../../helpers/files";
 import { useFixture } from "../../helpers/integration";
 
-describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[Asset Transfer, Asset Freeze]", function () {
+describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[Asset Transfer, Asset Freeze..]", function () {
   useFixture("inner-transaction");
   const fee = 1000;
   const minBalance = ALGORAND_ACCOUNT_MIN_BALANCE * 50 + fee;

--- a/packages/runtime/test/integration/inner-transaction/asset-tx.ts
+++ b/packages/runtime/test/integration/inner-transaction/asset-tx.ts
@@ -418,8 +418,8 @@ describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[Asset Transfer, 
 
     const asaDef = runtime.getAssetDef(Number(createdAsaID));
     // you can also get asa definition from passed asa name
-    const asaDefFromName = runtime.getAssetInfoFromName("asa_name")?.assetDef;
-    assert.deepEqual(asaDef, asaDefFromName as any);
+    const asaDefFromName = runtime.getAssetInfoFromName("asa_name")?.assetDef as any;
+    assert.deepEqual(asaDef, asaDefFromName);
 
     assert.isDefined(asaDef);
     assert.equal(asaDef.decimals, 0);

--- a/packages/runtime/test/integration/inner-transaction/asset-tx.ts
+++ b/packages/runtime/test/integration/inner-transaction/asset-tx.ts
@@ -43,12 +43,12 @@ describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[Asset Transfer, 
   this.beforeEach(() => {
     // reset app (delete + create)
     john.createdApps.delete(appID);
-    appID = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram).appID as number;
+    appID = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram).appID;
     appAccount = runtime.getAccount(getApplicationAddress(appID)); // update app account
 
     // create asset
     assetID = runtime.addAsset('gold',
-      { creator: { ...john.account, name: "john" } }).assetID as number;
+      { creator: { ...john.account, name: "john" } }).assetID;
 
     // fund app (escrow belonging to app) with 10 ALGO
     const fundAppParams: types.AlgoTransferParam = {

--- a/packages/runtime/test/integration/inner-transaction/payment.ts
+++ b/packages/runtime/test/integration/inner-transaction/payment.ts
@@ -39,7 +39,7 @@ describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[ALGO Payment]", 
   });
 
   this.beforeEach(() => {
-    appID = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram);
+    appID = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram).appID as number;
     appAccount = runtime.getAccount(getApplicationAddress(appID)); // update app account
 
     // fund app (escrow belonging to app) with 10 ALGO

--- a/packages/runtime/test/integration/inner-transaction/payment.ts
+++ b/packages/runtime/test/integration/inner-transaction/payment.ts
@@ -39,7 +39,7 @@ describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[ALGO Payment]", 
   });
 
   this.beforeEach(() => {
-    appID = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram).appID as number;
+    appID = runtime.addApp(appCreationFlags, {}, approvalProgram, clearProgram).appID;
     appAccount = runtime.getAccount(getApplicationAddress(appID)); // update app account
 
     // fund app (escrow belonging to app) with 10 ALGO

--- a/packages/runtime/test/integration/pooled-op-cost.ts
+++ b/packages/runtime/test/integration/pooled-op-cost.ts
@@ -33,7 +33,7 @@ describe("TEALv5: Pooled Opcode Cost calculation", function () {
       localInts: 1
     };
 
-    appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number;
+    appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID;
 
     appCallParam = {
       type: types.TransactionType.CallApp,

--- a/packages/runtime/test/integration/pooled-op-cost.ts
+++ b/packages/runtime/test/integration/pooled-op-cost.ts
@@ -33,7 +33,7 @@ describe("TEALv5: Pooled Opcode Cost calculation", function () {
       localInts: 1
     };
 
-    appID = runtime.addApp(flags, {}, approvalProgram, clearProgram);
+    appID = runtime.addApp(flags, {}, approvalProgram, clearProgram).appID as number;
 
     appCallParam = {
       type: types.TransactionType.CallApp,

--- a/packages/runtime/test/integration/pooled-op-cost.ts
+++ b/packages/runtime/test/integration/pooled-op-cost.ts
@@ -1,0 +1,80 @@
+import { types } from "@algo-builder/web";
+import { assert } from "chai";
+
+import { RUNTIME_ERRORS } from "../../src/errors/errors-list";
+import { AccountStore, Runtime } from "../../src/index";
+import { AppDeploymentFlags } from "../../src/types";
+import { getProgram } from "../helpers/files";
+import { useFixture } from "../helpers/integration";
+import { expectRuntimeError } from "../helpers/runtime-errors";
+
+const STR_NORMAL_COST = 'normal_cost';
+
+describe("TEALv5: Pooled Opcode Cost calculation", function () {
+  useFixture("stateful");
+  const john = new AccountStore(10e6);
+
+  let runtime: Runtime;
+  let approvalProgram: string;
+  let clearProgram: string;
+  let flags: AppDeploymentFlags;
+  let appID: number;
+  let appCallParam: types.AppCallsParam;
+  this.beforeAll(async function () {
+    runtime = new Runtime([john]); // setup test
+    approvalProgram = getProgram('pooled-opcode-budget.teal');
+    clearProgram = getProgram('clear.teal');
+
+    flags = {
+      sender: john.account,
+      globalBytes: 1,
+      globalInts: 1,
+      localBytes: 1,
+      localInts: 1
+    };
+
+    appID = runtime.addApp(flags, {}, approvalProgram, clearProgram);
+
+    appCallParam = {
+      type: types.TransactionType.CallApp,
+      sign: types.SignType.SecretKey,
+      fromAccount: john.account,
+      appID: appID,
+      payFlags: { totalFee: 1000 },
+      appArgs: ['str:exceeded_cost']
+    };
+  });
+
+  it("should fail on application call if total pooled cost exceeds", function () {
+    expectRuntimeError(
+      () => runtime.executeTx(appCallParam), // exceeded on single
+      RUNTIME_ERRORS.TEAL.MAX_COST_EXCEEDED
+    );
+
+    // exceed even with 3 "normal transactions"
+    expectRuntimeError(
+      () => runtime.executeTx([
+        appCallParam,
+        { ...appCallParam, appArgs: [`str:${STR_NORMAL_COST}`] },
+        { ...appCallParam, appArgs: [`str:${STR_NORMAL_COST}`] },
+        { ...appCallParam, appArgs: [`str:${STR_NORMAL_COST}`] }
+      ]), // exceeded on single
+      RUNTIME_ERRORS.TEAL.MAX_COST_EXCEEDED
+    );
+  });
+
+  it("should pass on app call with total pooled cost if enough transactions are present in group", function () {
+    // enough normal cost transactions in group
+    const passTxGroup = [
+      appCallParam,
+      { ...appCallParam, appArgs: [`str:${STR_NORMAL_COST}`] },
+      { ...appCallParam, appArgs: [`str:${STR_NORMAL_COST}`] },
+      { ...appCallParam, appArgs: [`str:${STR_NORMAL_COST}`] },
+      { ...appCallParam, appArgs: [`str:${STR_NORMAL_COST}`] },
+      { ...appCallParam, appArgs: [`str:${STR_NORMAL_COST}`] },
+      { ...appCallParam, appArgs: [`str:${STR_NORMAL_COST}`] }
+    ];
+
+    assert.doesNotThrow(() => runtime.executeTx(passTxGroup));
+  });
+});

--- a/packages/runtime/test/integration/stateful-counter.ts
+++ b/packages/runtime/test/integration/stateful-counter.ts
@@ -12,7 +12,7 @@ describe("Algorand Smart Contracts - Stateful Counter example", function () {
   const minBalance = ALGORAND_ACCOUNT_MIN_BALANCE * 10 + fee;
   const john = new AccountStore(minBalance + fee);
 
-  const txnParams: types.ExecParams = {
+  const txParams: types.ExecParams = {
     type: types.TransactionType.CallApp,
     sign: types.SignType.SecretKey,
     fromAccount: john.account,
@@ -29,7 +29,7 @@ describe("Algorand Smart Contracts - Stateful Counter example", function () {
     clearProgram = getProgram('clear.teal');
 
     // create new app
-    txnParams.appID = runtime.addApp({
+    txParams.appID = runtime.addApp({
       sender: john.account,
       globalBytes: 2,
       globalInts: 2,
@@ -38,40 +38,40 @@ describe("Algorand Smart Contracts - Stateful Counter example", function () {
     }, {}, approvalProgram, clearProgram).appID;
 
     // opt-in to the app
-    runtime.optInToApp(john.address, txnParams.appID, {}, {});
+    runtime.optInToApp(john.address, txParams.appID, {}, {});
   });
 
   const key = "counter";
 
   it("should initialize local counter to 0 after opt-in", function () {
-    const localCounter = runtime.getAccount(john.address).getLocalState(txnParams.appID, key); // get local value from john account
+    const localCounter = runtime.getAccount(john.address).getLocalState(txParams.appID, key); // get local value from john account
     assert.isDefined(localCounter); // there should be a value present in local state with key "counter"
     assert.equal(localCounter, 0n);
   });
 
   it("should set global and local counter to 1 on first call", function () {
-    runtime.executeTx(txnParams);
+    runtime.executeTx(txParams);
 
-    const globalCounter = runtime.getGlobalState(txnParams.appID, key);
+    const globalCounter = runtime.getGlobalState(txParams.appID, key);
     assert.equal(globalCounter, 1n);
 
-    const localCounter = runtime.getAccount(john.address).getLocalState(txnParams.appID, key); // get local value from john account
+    const localCounter = runtime.getAccount(john.address).getLocalState(txParams.appID, key); // get local value from john account
     assert.equal(localCounter, 1n);
   });
 
   it("should update counter by +1 for both global and local states on second call", function () {
-    const globalCounter = runtime.getGlobalState(txnParams.appID, key) as bigint;
-    const localCounter = runtime.getAccount(john.address).getLocalState(txnParams.appID, key) as bigint;
+    const globalCounter = runtime.getGlobalState(txParams.appID, key) as bigint;
+    const localCounter = runtime.getAccount(john.address).getLocalState(txParams.appID, key) as bigint;
 
     // verfify that both counters are set to 1 (by the previous test)
     assert.equal(globalCounter, 1n);
     assert.equal(localCounter, 1n);
 
-    runtime.executeTx(txnParams);
+    runtime.executeTx(txParams);
 
     // after execution the counters should be updated by +1
-    const newGlobalCounter = runtime.getGlobalState(txnParams.appID, key);
-    const newLocalCounter = runtime.getAccount(john.address).getLocalState(txnParams.appID, key);
+    const newGlobalCounter = runtime.getGlobalState(txParams.appID, key);
+    const newLocalCounter = runtime.getAccount(john.address).getLocalState(txParams.appID, key);
 
     assert.equal(newGlobalCounter, globalCounter + 1n);
     assert.equal(newLocalCounter, localCounter + 1n);

--- a/packages/runtime/test/integration/stateful-counter.ts
+++ b/packages/runtime/test/integration/stateful-counter.ts
@@ -35,7 +35,7 @@ describe("Algorand Smart Contracts - Stateful Counter example", function () {
       globalInts: 2,
       localBytes: 3,
       localInts: 3
-    }, {}, approvalProgram, clearProgram);
+    }, {}, approvalProgram, clearProgram).appID as number;
 
     // opt-in to the app
     runtime.optInToApp(john.address, txnParams.appID, {}, {});

--- a/packages/runtime/test/integration/stateful-counter.ts
+++ b/packages/runtime/test/integration/stateful-counter.ts
@@ -35,7 +35,7 @@ describe("Algorand Smart Contracts - Stateful Counter example", function () {
       globalInts: 2,
       localBytes: 3,
       localInts: 3
-    }, {}, approvalProgram, clearProgram).appID as number;
+    }, {}, approvalProgram, clearProgram).appID;
 
     // opt-in to the app
     runtime.optInToApp(john.address, txnParams.appID, {}, {});

--- a/packages/runtime/test/integration/sub-routine.ts
+++ b/packages/runtime/test/integration/sub-routine.ts
@@ -57,7 +57,7 @@ describe("TEALv4: Sub routine", function () {
 
   it("should calculate correct fibonacci number", () => {
     const fibProg = getProgram('fibonacci.teal');
-    let appID = runtime.addApp(flags, {}, fibProg, clearProgram);
+    let appID = runtime.addApp(flags, {}, fibProg, clearProgram).appID as number;
 
     // 5th fibonacci
     let result = runtime.getGlobalState(appID, 'result');
@@ -65,21 +65,21 @@ describe("TEALv4: Sub routine", function () {
 
     // 6th fibonacci
     flags.appArgs = ['int:6'];
-    appID = runtime.addApp(flags, {}, fibProg, clearProgram);
+    appID = runtime.addApp(flags, {}, fibProg, clearProgram).appID as number;
     result = runtime.getGlobalState(appID, 'result');
 
     assert.equal(result, 8n);
 
     // 8th fibonacci
     flags.appArgs = ['int:8'];
-    appID = runtime.addApp(flags, {}, fibProg, clearProgram);
+    appID = runtime.addApp(flags, {}, fibProg, clearProgram).appID as number;
     result = runtime.getGlobalState(appID, 'result');
 
     assert.equal(result, 21n);
 
     // 1st fibonacci
     flags.appArgs = ['int:1'];
-    appID = runtime.addApp(flags, {}, fibProg, clearProgram);
+    appID = runtime.addApp(flags, {}, fibProg, clearProgram).appID as number;
     result = runtime.getGlobalState(appID, 'result');
 
     assert.equal(result, 1n);

--- a/packages/runtime/test/integration/sub-routine.ts
+++ b/packages/runtime/test/integration/sub-routine.ts
@@ -57,7 +57,7 @@ describe("TEALv4: Sub routine", function () {
 
   it("should calculate correct fibonacci number", () => {
     const fibProg = getProgram('fibonacci.teal');
-    let appID = runtime.addApp(flags, {}, fibProg, clearProgram).appID as number;
+    let appID = runtime.addApp(flags, {}, fibProg, clearProgram).appID;
 
     // 5th fibonacci
     let result = runtime.getGlobalState(appID, 'result');
@@ -65,21 +65,21 @@ describe("TEALv4: Sub routine", function () {
 
     // 6th fibonacci
     flags.appArgs = ['int:6'];
-    appID = runtime.addApp(flags, {}, fibProg, clearProgram).appID as number;
+    appID = runtime.addApp(flags, {}, fibProg, clearProgram).appID;
     result = runtime.getGlobalState(appID, 'result');
 
     assert.equal(result, 8n);
 
     // 8th fibonacci
     flags.appArgs = ['int:8'];
-    appID = runtime.addApp(flags, {}, fibProg, clearProgram).appID as number;
+    appID = runtime.addApp(flags, {}, fibProg, clearProgram).appID;
     result = runtime.getGlobalState(appID, 'result');
 
     assert.equal(result, 21n);
 
     // 1st fibonacci
     flags.appArgs = ['int:1'];
-    appID = runtime.addApp(flags, {}, fibProg, clearProgram).appID as number;
+    appID = runtime.addApp(flags, {}, fibProg, clearProgram).appID;
     result = runtime.getGlobalState(appID, 'result');
 
     assert.equal(result, 1n);

--- a/packages/runtime/test/integration/tx-array-len.ts
+++ b/packages/runtime/test/integration/tx-array-len.ts
@@ -40,7 +40,7 @@ describe("Algorand Stateful Smart Contracts - Consensus Params", function () {
       globalInts: 2,
       localBytes: 3,
       localInts: 3
-    }, {}, approvalProgram, clearProgram).appID as number;
+    }, {}, approvalProgram, clearProgram).appID;
 
     // opt-in to the app
     runtime.optInToApp(john.address, txnParams.appID, {}, {});

--- a/packages/runtime/test/integration/tx-array-len.ts
+++ b/packages/runtime/test/integration/tx-array-len.ts
@@ -40,7 +40,7 @@ describe("Algorand Stateful Smart Contracts - Consensus Params", function () {
       globalInts: 2,
       localBytes: 3,
       localInts: 3
-    }, {}, approvalProgram, clearProgram);
+    }, {}, approvalProgram, clearProgram).appID as number;
 
     // opt-in to the app
     runtime.optInToApp(john.address, txnParams.appID, {}, {});

--- a/packages/runtime/test/integration/updateApp.ts
+++ b/packages/runtime/test/integration/updateApp.ts
@@ -42,7 +42,7 @@ describe("Algorand Smart Contracts - Update Application", function () {
   });
 
   it("should update application", function () {
-    appID = runtime.addApp(flags, {}, oldApprovalProgram, clearProgram);
+    appID = runtime.addApp(flags, {}, oldApprovalProgram, clearProgram).appID as number;
     runtime.optInToApp(creator.address, appID, {}, {});
 
     // check created app params
@@ -78,7 +78,7 @@ describe("Algorand Smart Contracts - Update Application", function () {
 
   it("should not update application if logic is rejected", function () {
     // create app
-    appID = runtime.addApp(flags, {}, oldApprovalProgram, clearProgram);
+    appID = runtime.addApp(flags, {}, oldApprovalProgram, clearProgram).appID as number;
     runtime.optInToApp(creator.address, appID, {}, {});
 
     let app = runtime.getApp(appID);

--- a/packages/runtime/test/integration/updateApp.ts
+++ b/packages/runtime/test/integration/updateApp.ts
@@ -42,7 +42,7 @@ describe("Algorand Smart Contracts - Update Application", function () {
   });
 
   it("should update application", function () {
-    appID = runtime.addApp(flags, {}, oldApprovalProgram, clearProgram).appID as number;
+    appID = runtime.addApp(flags, {}, oldApprovalProgram, clearProgram).appID;
     runtime.optInToApp(creator.address, appID, {}, {});
 
     // check created app params
@@ -78,7 +78,7 @@ describe("Algorand Smart Contracts - Update Application", function () {
 
   it("should not update application if logic is rejected", function () {
     // create app
-    appID = runtime.addApp(flags, {}, oldApprovalProgram, clearProgram).appID as number;
+    appID = runtime.addApp(flags, {}, oldApprovalProgram, clearProgram).appID;
     runtime.optInToApp(creator.address, appID, {}, {});
 
     let app = runtime.getApp(appID);

--- a/packages/runtime/test/src/interpreter/inner-transaction.ts
+++ b/packages/runtime/test/src/interpreter/inner-transaction.ts
@@ -43,12 +43,18 @@ describe("TEALv5: Inner Transactions", function () {
   const reset = (): void => {
     while (interpreter.stack.length() !== 0) { interpreter.stack.pop(); }
     interpreter.subTxn = undefined;
+    interpreter.runtime.ctx.pooledApplCost = 0;
     interpreter.instructions = [];
     interpreter.innerTxns = [];
     interpreter.instructionIndex = 0;
     interpreter.runtime.ctx.tx = { ...TXN_OBJ, snd: Buffer.from(elonPk) };
     interpreter.runtime.ctx.gtxs = [interpreter.runtime.ctx.tx];
     interpreter.runtime.ctx.isInnerTx = false;
+    // set new tx receipt
+    interpreter.runtime.ctx.state.txnInfo.set(TXN_OBJ.txID, {
+      txn: TXN_OBJ,
+      txID: TXN_OBJ.txID
+    });
   };
 
   const setUpInterpreter = (): void => {
@@ -61,6 +67,7 @@ describe("TEALv5: Inner Transactions", function () {
   const executeTEAL = (tealCode: string): void => {
     // reset interpreter
     reset();
+
     interpreter.execute(tealCode, ExecutionMode.APPLICATION, interpreter.runtime, 0);
   };
 
@@ -655,7 +662,7 @@ describe("TEALv5: Inner Transactions", function () {
           { total: 10, decimals: 0, unitName: "TASA" },
           elonAddr,
           { creator: { ...elonAcc.account, name: 'elon' } }
-        );
+        ).assetID;
       }
 
       // passes
@@ -734,7 +741,7 @@ describe("TEALv5: Inner Transactions", function () {
           { total: 11, decimals: 0, unitName: "TASA1" },
           elonAddr,
           { creator: { ...elonAcc.account, name: 'elon' } }
-        );
+        ).assetID;
 
         // not in foreign-assets
         assetID2 = interpreter.runtime.ctx.addASADef(
@@ -742,7 +749,7 @@ describe("TEALv5: Inner Transactions", function () {
           { total: 22, decimals: 0, unitName: "TASA2" },
           elonAddr,
           { creator: { ...elonAcc.account, name: 'elon' } }
-        );
+        ).assetID;
       }
 
       axfer = `
@@ -1082,6 +1089,89 @@ describe("TEALv5: Inner Transactions", function () {
       // verify unfreeze
       johnHolding = interpreter.runtime.getAssetHolding(createdAssetID, johnAddr);
       assert.equal(johnHolding["is-frozen"], false);
+    });
+  });
+
+  describe("Log", () => {
+    it(`should log bytes to current transaction receipt`, function () {
+      const txnInfo = interpreter.runtime.getTransactionInfo(TXN_OBJ.txID);
+      assert.isUndefined(txnInfo?.logs); // no logs before
+
+      const log = `#pragma version 5
+        int 1
+        // log 30 times "a"
+        loop:
+        byte "a"
+        log
+        int 1
+        +
+        dup
+        int 30
+        <=
+        bnz loop
+        byte "b"
+        log
+        byte "c"
+        log
+      `;
+
+      assert.doesNotThrow(() => executeTEAL(log));
+      const logs = interpreter.runtime.getTransactionInfo(TXN_OBJ.txID)?.logs as string[];
+      assert.isDefined(logs);
+
+      for (let i = 0; i < 30; ++i) { assert.equal(logs[i], "a"); }
+      assert.equal(logs[30], "b");
+      assert.equal(logs[31], "c");
+    });
+
+    it(`should throw error if log count exceeds threshold`, function () {
+      const log = `#pragma version 5
+        int 1
+        // log 33 times "a" (exceeds threshold of 32)
+        loop:
+        byte "a"
+        log
+        int 1
+        +
+        dup
+        int 33
+        <=
+        bnz loop
+        byte "b"
+        log
+        byte "c"
+        log
+      `;
+
+      expectRuntimeError(
+        () => executeTEAL(log),
+        RUNTIME_ERRORS.TEAL.LOGS_COUNT_EXCEEDED_THRESHOLD
+      );
+    });
+
+    it(`should throw error if logs "length" exceeds threshold`, function () {
+      const log = `#pragma version 5
+        int 1
+        // too long
+        loop:
+        byte "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
+        log
+        int 1
+        +
+        dup
+        int 30
+        <=
+        bnz loop
+        byte "b"
+        log
+        byte "c"
+        log
+      `;
+
+      expectRuntimeError(
+        () => executeTEAL(log),
+        RUNTIME_ERRORS.TEAL.LOGS_LENGTH_EXCEEDED_THRESHOLD
+      );
     });
   });
 });

--- a/packages/runtime/test/src/interpreter/inner-transaction.ts
+++ b/packages/runtime/test/src/interpreter/inner-transaction.ts
@@ -51,7 +51,7 @@ describe("TEALv5: Inner Transactions", function () {
     interpreter.runtime.ctx.gtxs = [interpreter.runtime.ctx.tx];
     interpreter.runtime.ctx.isInnerTx = false;
     // set new tx receipt
-    interpreter.runtime.ctx.state.txnInfo.set(TXN_OBJ.txID, {
+    interpreter.runtime.ctx.state.txReceipts.set(TXN_OBJ.txID, {
       txn: TXN_OBJ,
       txID: TXN_OBJ.txID
     });
@@ -1094,7 +1094,7 @@ describe("TEALv5: Inner Transactions", function () {
 
   describe("Log", () => {
     it(`should log bytes to current transaction receipt`, function () {
-      const txnInfo = interpreter.runtime.getTransactionInfo(TXN_OBJ.txID);
+      const txnInfo = interpreter.runtime.getTxReceipt(TXN_OBJ.txID);
       assert.isUndefined(txnInfo?.logs); // no logs before
 
       const log = `#pragma version 5
@@ -1116,7 +1116,7 @@ describe("TEALv5: Inner Transactions", function () {
       `;
 
       assert.doesNotThrow(() => executeTEAL(log));
-      const logs = interpreter.runtime.getTransactionInfo(TXN_OBJ.txID)?.logs as string[];
+      const logs = interpreter.runtime.getTxReceipt(TXN_OBJ.txID)?.logs as string[];
       assert.isDefined(logs);
 
       for (let i = 0; i < 30; ++i) { assert.equal(logs[i], "a"); }

--- a/packages/runtime/test/src/interpreter/opcode-list.ts
+++ b/packages/runtime/test/src/interpreter/opcode-list.ts
@@ -5788,14 +5788,14 @@ describe("Teal Opcodes", function () {
       let txID: string;
       this.beforeAll(() => {
         txID = interpreter.runtime.ctx.tx.txID;
-        interpreter.runtime.ctx.state.txnInfo.set(txID, {
+        interpreter.runtime.ctx.state.txReceipts.set(txID, {
           txn: interpreter.runtime.ctx.tx,
           txID: txID
         });
       });
 
       it("should push arg_0 from argument array to stack", function () {
-        let txInfo = interpreter.runtime.ctx.state.txnInfo.get(txID);
+        let txInfo = interpreter.runtime.ctx.state.txReceipts.get(txID);
         assert.isUndefined(txInfo?.logs);
         const op = new Log([], 1, interpreter);
 
@@ -5806,7 +5806,7 @@ describe("Teal Opcodes", function () {
         stack.push(parsing.stringToBytes("That's lame"));
         op.execute(stack);
 
-        txInfo = interpreter.runtime.ctx.state.txnInfo.get(txID);
+        txInfo = interpreter.runtime.ctx.state.txReceipts.get(txID);
         assert.deepEqual(txInfo?.logs, [
           'Hello', 'Friend?', "That's lame"
         ]);

--- a/packages/runtime/test/src/interpreter/opcode-list.ts
+++ b/packages/runtime/test/src/interpreter/opcode-list.ts
@@ -33,7 +33,7 @@ import { ALGORAND_ACCOUNT_MIN_BALANCE, ASSET_CREATION_FEE, DEFAULT_STACK_ELEM, M
 import { bigEndianBytesToBigInt, convertToBuffer, getEncoding } from "../../../src/lib/parsing";
 import { Stack } from "../../../src/lib/stack";
 import { parseToStackElem } from "../../../src/lib/txn";
-import { AccountStoreI, EncodingType, StackElem, Txn as EncodedTx, TxReceipt } from "../../../src/types";
+import { AccountStoreI, EncodingType, EncTx as EncodedTx, StackElem } from "../../../src/types";
 import { useFixture } from "../../helpers/integration";
 import { execExpectError, expectRuntimeError } from "../../helpers/runtime-errors";
 import { accInfo } from "../../mocks/stateful";
@@ -3096,7 +3096,7 @@ describe("Teal Opcodes", function () {
       assert.equal(MAX_UINT64, stack.pop());
     });
 
-    it("Int: should push correct TxnOnComplete enum value to stack", function () {
+    it("Int: should push correct TxOnComplete enum value to stack", function () {
       let op = new Int(['NoOp'], 0);
       op.execute(stack);
       assert.equal(1, stack.length());

--- a/packages/runtime/test/src/runtime.ts
+++ b/packages/runtime/test/src/runtime.ts
@@ -183,7 +183,7 @@ describe("Algorand Standard Assets", function () {
 
   this.beforeEach(() => {
     assetId = runtime.addAsset('gold',
-      { creator: { ...john.account, name: "john" } }).assetID as number;
+      { creator: { ...john.account, name: "john" } }).assetID;
     assetTransferParam.assetID = assetId;
     syncAccounts();
   });
@@ -196,7 +196,7 @@ describe("Algorand Standard Assets", function () {
   it("should create asset using asa.yaml file and raise account minimum balance", () => {
     const initialMinBalance = john.minBalance;
     assetId =
-      runtime.addAsset('gold', { creator: { ...john.account, name: "john" } }).assetID as number;
+      runtime.addAsset('gold', { creator: { ...john.account, name: "john" } }).assetID;
     syncAccounts();
 
     const res = runtime.getAssetDef(assetId);
@@ -228,7 +228,7 @@ describe("Algorand Standard Assets", function () {
     };
     assetId = runtime.addASADef(
       expected.name, expected.asaDef, { creator: { ...john.account, name: "john" } }
-    ).assetID as number;
+    ).assetID;
     syncAccounts();
 
     const res = runtime.getAssetDef(assetId);
@@ -464,7 +464,7 @@ describe("Algorand Standard Assets", function () {
 
   it("Blank field test, should not modify asset because field is set to blank", () => {
     const assetId = runtime.addAsset('silver',
-      { creator: { ...john.account, name: "john" } }).assetID as number;
+      { creator: { ...john.account, name: "john" } }).assetID;
 
     const modFields: types.AssetModFields = {
       manager: bob.address,
@@ -754,14 +754,14 @@ describe("Stateful Smart Contracts", function () {
   });
 
   it("Should create application", () => {
-    const appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram).appID as number;
+    const appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram).appID;
 
     const app = runtime.getApp(appID);
     assert.isDefined(app);
   });
 
   it("Should not update application if approval or clear program is empty", () => {
-    const appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram).appID as number;
+    const appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram).appID;
 
     expectRuntimeError(
       () => runtime.updateApp(john.address, appID, "", clearProgram, {}, {}),

--- a/packages/runtime/test/src/runtime.ts
+++ b/packages/runtime/test/src/runtime.ts
@@ -23,11 +23,11 @@ describe("Logic Signature Transaction in Runtime", function () {
 
   let runtime: Runtime;
   let lsig: LogicSigAccount;
-  let txnParam: types.ExecParams;
+  let txParam: types.ExecParams;
   this.beforeAll(function () {
     runtime = new Runtime([john, bob, alice]);
     lsig = runtime.createLsigAccount(getProgram(programName), []);
-    txnParam = {
+    txParam = {
       type: types.TransactionType.TransferAlgo,
       sign: types.SignType.LogicSignature,
       fromAccountAddr: john.account.addr,
@@ -40,7 +40,7 @@ describe("Logic Signature Transaction in Runtime", function () {
 
   it("should execute the lsig and verify john(delegated signature)", () => {
     lsig.sign(john.account.sk);
-    runtime.executeTx(txnParam);
+    runtime.executeTx(txParam);
 
     // balance should be updated because logic is verified and accepted
     const bobAcc = runtime.getAccount(bob.address);
@@ -49,7 +49,7 @@ describe("Logic Signature Transaction in Runtime", function () {
 
   it("should not verify signature because alice sent it", () => {
     const invalidParams: types.ExecParams = {
-      ...txnParam,
+      ...txParam,
       sign: types.SignType.LogicSignature,
       fromAccountAddr: alice.account.addr,
       lsig: lsig
@@ -65,7 +65,7 @@ describe("Logic Signature Transaction in Runtime", function () {
   it("should verify signature but reject logic", async () => {
     const logicSig = runtime.createLsigAccount(getProgram("reject.teal"), []);
     const txParams: types.ExecParams = {
-      ...txnParam,
+      ...txParam,
       sign: types.SignType.LogicSignature,
       fromAccountAddr: john.account.addr,
       lsig: logicSig
@@ -87,12 +87,12 @@ describe("Rounds Test", function () {
   let john = new AccountStore(minBalance);
   let bob = new AccountStore(minBalance);
   let runtime: Runtime;
-  let txnParams: types.AlgoTransferParam;
+  let txParams: types.AlgoTransferParam;
   this.beforeAll(function () {
     runtime = new Runtime([john, bob]); // setup test
 
     // set up transaction paramenters
-    txnParams = {
+    txParams = {
       type: types.TransactionType.TransferAlgo, // payment
       sign: types.SignType.SecretKey,
       fromAccount: john.account,
@@ -106,8 +106,8 @@ describe("Rounds Test", function () {
     john = new AccountStore(minBalance);
     bob = new AccountStore(minBalance);
     runtime = new Runtime([john, bob]);
-    txnParams = {
-      ...txnParams,
+    txParams = {
+      ...txParams,
       sign: types.SignType.SecretKey,
       fromAccount: john.account,
       toAccountAddr: bob.address
@@ -120,10 +120,10 @@ describe("Rounds Test", function () {
   }
 
   it("should succeed if current round is between first and last valid", () => {
-    txnParams.payFlags = { totalFee: 1000, firstValid: 5, validRounds: 200 };
+    txParams.payFlags = { totalFee: 1000, firstValid: 5, validRounds: 200 };
     runtime.setRoundAndTimestamp(20, 20);
 
-    runtime.executeTx(txnParams);
+    runtime.executeTx(txParams);
 
     // get final state (updated accounts)
     syncAccounts();
@@ -135,15 +135,15 @@ describe("Rounds Test", function () {
     runtime.setRoundAndTimestamp(3, 20);
 
     expectRuntimeError(
-      () => runtime.executeTx(txnParams),
+      () => runtime.executeTx(txParams),
       RUNTIME_ERRORS.GENERAL.INVALID_ROUND
     );
   });
 
   it("should succeeded by default (no round requirement is passed)", () => {
-    txnParams.payFlags = { totalFee: 1000 };
+    txParams.payFlags = { totalFee: 1000 };
 
-    runtime.executeTx(txnParams);
+    runtime.executeTx(txParams);
 
     // get final state (updated accounts)
     syncAccounts();

--- a/packages/runtime/test/src/runtime.ts
+++ b/packages/runtime/test/src/runtime.ts
@@ -183,7 +183,7 @@ describe("Algorand Standard Assets", function () {
 
   this.beforeEach(() => {
     assetId = runtime.addAsset('gold',
-      { creator: { ...john.account, name: "john" } });
+      { creator: { ...john.account, name: "john" } }).assetID as number;
     assetTransferParam.assetID = assetId;
     syncAccounts();
   });
@@ -195,7 +195,8 @@ describe("Algorand Standard Assets", function () {
 
   it("should create asset using asa.yaml file and raise account minimum balance", () => {
     const initialMinBalance = john.minBalance;
-    assetId = runtime.addAsset('gold', { creator: { ...john.account, name: "john" } });
+    assetId =
+      runtime.addAsset('gold', { creator: { ...john.account, name: "john" } }).assetID as number;
     syncAccounts();
 
     const res = runtime.getAssetDef(assetId);
@@ -227,7 +228,7 @@ describe("Algorand Standard Assets", function () {
     };
     assetId = runtime.addASADef(
       expected.name, expected.asaDef, { creator: { ...john.account, name: "john" } }
-    );
+    ).assetID as number;
     syncAccounts();
 
     const res = runtime.getAssetDef(assetId);
@@ -463,7 +464,7 @@ describe("Algorand Standard Assets", function () {
 
   it("Blank field test, should not modify asset because field is set to blank", () => {
     const assetId = runtime.addAsset('silver',
-      { creator: { ...john.account, name: "john" } });
+      { creator: { ...john.account, name: "john" } }).assetID as number;
 
     const modFields: types.AssetModFields = {
       manager: bob.address,
@@ -753,14 +754,14 @@ describe("Stateful Smart Contracts", function () {
   });
 
   it("Should create application", () => {
-    const appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram);
+    const appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram).appID as number;
 
     const app = runtime.getApp(appID);
     assert.isDefined(app);
   });
 
   it("Should not update application if approval or clear program is empty", () => {
-    const appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram);
+    const appID = runtime.addApp(creationFlags, {}, approvalProgram, clearProgram).appID as number;
 
     expectRuntimeError(
       () => runtime.updateApp(john.address, appID, "", clearProgram, {}, {}),


### PR DESCRIPTION
## Proposed Changes

+ added opcodes: `Txnas, Gtxnas, Gtxnsas, Args, Log`. Added tests.
+ Update all transaction functions (eg. `executeTx`, `addAsset`, `addApp` ..etc) to return a transaction receipt. 

NOTE: this introduces a breaking change for `.addAsset` & `.addApp`

## Potential followups
[DONE] integration test for `log` op 