### PR TITLE
Increase appCounter, assetCounter in runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     * Support Inner Transactions: `Payment`, `AssetTransfer`, `AssetFreeze`, `AssetRevoke`, `AssetDeploy`, `AssetModify`, `AssetDelete`.
     * Support Pooled opcode budget
 + Add Asset Name to `assetDefinition` in `@algo-builder/runtime`.
++ Updated App, Asset counters in runtime from 0, to 8. This means that the newly created App/Asset Index will be 9 (instead of 1).
 
 ### Breaking changes
 

--- a/examples/dao/test/failing-path.js
+++ b/examples/dao/test/failing-path.js
@@ -10,7 +10,7 @@ const now = Math.round(new Date().getTime() / 1000);
 const RUNTIME_ERR1009 = 'RUNTIME_ERR1009: TEAL runtime encountered err opcode';
 const INDEX_OUT_OF_BOUND_ERR = 'RUNTIME_ERR1008: Index out of bound';
 const INTEGER_UNDERFLOW_ERR = 'Result of current operation caused integer underflow';
-const APP_NOT_FOUND = 'RUNTIME_ERR1306: Application Index 1 not found or is invalid';
+const APP_NOT_FOUND = 'RUNTIME_ERR1306: Application Index 9 not found or is invalid';
 
 describe('DAO - Failing Paths', function () {
   let master, creator, proposer, voterA, voterB;

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -9,7 +9,7 @@ import { Ctx } from "./ctx";
 import { RUNTIME_ERRORS } from "./errors/errors-list";
 import { RuntimeError } from "./errors/runtime-errors";
 import { Interpreter, loadASAFile } from "./index";
-import { ALGORAND_ACCOUNT_MIN_BALANCE, ZERO_ADDRESS_STR } from "./lib/constants";
+import { ALGORAND_ACCOUNT_MIN_BALANCE, ALGORAND_MAX_TX_ARRAY_LEN, ZERO_ADDRESS_STR } from "./lib/constants";
 import { convertToString } from "./lib/parsing";
 import { LogicSigAccount } from "./logicsig";
 import { mockSuggestedParams } from "./mock/tx";
@@ -43,8 +43,8 @@ export class Runtime {
       assetDefs: new Map<number, AccountAddress>(), // number represents assetId
       assetNameInfo: new Map<string, ASAInfo>(),
       appNameInfo: new Map<string, SSCInfo>(),
-      appCounter: 0, // initialize app counter with 0
-      assetCounter: 0 // initialize asset counter with 0
+      appCounter: ALGORAND_MAX_TX_ARRAY_LEN, // initialize app counter with 8
+      assetCounter: ALGORAND_MAX_TX_ARRAY_LEN // initialize asset counter with 8
     };
 
     // intialize accounts (should be done during runtime initialization)

--- a/packages/runtime/test/integration/atomic-transfer.ts
+++ b/packages/runtime/test/integration/atomic-transfer.ts
@@ -101,7 +101,7 @@ describe("Algorand Smart Contracts - Atomic Transfers", function () {
         fromAccount: alice.account,
         toAccountAddr: john.address,
         amount: 1000,
-        assetID: 1,
+        assetID: 9,
         payFlags: { totalFee: 1000 }
       }
     ];

--- a/packages/runtime/test/integration/inner-transaction/asset-tx.ts
+++ b/packages/runtime/test/integration/inner-transaction/asset-tx.ts
@@ -126,7 +126,7 @@ describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[Asset Transfer, 
     };
     assert.throws(
       () => runtime.executeTx(transferASAbyAppParam),
-      `RUNTIME_ERR1404: Account ${appAccount.address} doesn't hold asset index 2`
+      `RUNTIME_ERR1404: Account ${appAccount.address} doesn't hold asset index ${assetID}`
     );
   });
 
@@ -243,7 +243,7 @@ describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[Asset Transfer, 
 
     assert.throws(
       () => runtime.executeTx(txParams),
-      `RUNTIME_ERR1404: Account ${elon.address} doesn't hold asset index 8`
+      `RUNTIME_ERR1404: Account ${elon.address} doesn't hold asset index ${assetID}`
     );
   });
 

--- a/packages/runtime/test/src/interpreter/inner-transaction.ts
+++ b/packages/runtime/test/src/interpreter/inner-transaction.ts
@@ -607,7 +607,7 @@ describe("TEALv5: Inner Transactions", function () {
     });
 
     it(`should fail: ref is passed but bal == 0`, function () {
-      TXN_OBJ.apas = [1]; // set foreign asset
+      TXN_OBJ.apas = [1, 9]; // set foreign asset
       expectRuntimeError(
         () => executeTEAL(axfer),
         RUNTIME_ERRORS.TRANSACTION.INSUFFICIENT_ACCOUNT_BALANCE
@@ -631,7 +631,7 @@ describe("TEALv5: Inner Transactions", function () {
         itxn_begin
         int axfer
         itxn_field TypeEnum
-        int 1
+        int 9
         itxn_field XferAsset
         int 0
         itxn_field AssetAmount


### PR DESCRIPTION
## Proposed Changes

Increase appCounter, assetCounter in runtime from 0 to 8. This is to avoid `accountRef()`, `asaRef()` indexing (as we always create a new asset/app with ID > foreign apps/asset length)
