### PR TITLE
Update app deploying to save app with params, load logic from cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
     ```
     For information about loading checkpoint(s) data using `@algo-builder/web` in a webapp, read [here](https://github.com/scale-it/algo-builder/blob/master/docs/guide/algob-web.md#checkpoints).
 + Added `WallectConnectSession` class to create & manage wallect connect session. User can use `session.executeTransaction()` to execute algob transactions using wallet connect.
++ Updated `deployer.deployApp()` & `deployer.updateApp()` to take one more optional parameter: `appName`. This will also save in a checkpoint the compiled app by name. Added new funtion `getAppByName(name: string)` to query checkpoint information by app name.
++ Added `deployer.loadLogicFromCache` to load a logic signature from already compiled TEAL codes (stored in `artifacts/cache`, for eg during `deployer.fundLsig`). This avoid re-compilation (and passing `scTmplParams`) each time(s) user wants to load an lsig.
 
 ### Breaking changes
 `@algo-builder/runtime`:

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -5,7 +5,7 @@ import * as algosdk from "algosdk";
 
 import { txWriter } from "../internal/tx-log-writer";
 import { AlgoOperator } from "../lib/algo-operator";
-import { getDummyLsig, getLsig } from "../lib/lsig";
+import { getDummyLsig, getLsig, getLsigFromCache } from "../lib/lsig";
 import { blsigExt, loadBinaryLsig, readMsigFromFile } from "../lib/msig";
 import { CheckpointFunctionsImpl, persistCheckpoint } from "../lib/script-checkpoints";
 import type {
@@ -179,6 +179,16 @@ class DeployerBasicMode {
    */
   async loadLogic (name: string, scTmplParams?: SCParams): Promise<LogicSigAccount> {
     return await getLsig(name, this.algoOp.algodClient, scTmplParams);
+  }
+
+  /**
+   * Loads logic signature from cache for contract mode. This helps user to avoid
+   * passing template parameters always during loading logic signature.
+   * @param name ASC name
+   * @returns loaded logic signature from artifacts/cache/<file_name>.teal.yaml
+   */
+  async loadLogicFromCache (name: string): Promise<LogicSigAccount> {
+    return await getLsigFromCache(name);
   }
 
   /**

--- a/packages/algob/src/lib/compile.ts
+++ b/packages/algob/src/lib/compile.ts
@@ -53,7 +53,6 @@ export class CompileOp {
       [teal, thash] = this.readTealAndHash(filePath);
     }
 
-    // const [teal, thash] = this.readTealAndHash(filePath);
     let a = await this.readArtifact(filename);
     if (!force && a !== undefined && a.srcHash === thash) {
       // '\x1b[33m%s\x1b[0m' for yellow color warning

--- a/packages/algob/src/lib/tx.ts
+++ b/packages/algob/src/lib/tx.ts
@@ -151,7 +151,7 @@ async function mkTx (
       break;
     }
     case wtypes.TransactionType.DeployApp: {
-      const name = String(txn.approvalProgram) + "-" + String(txn.clearProgram);
+      const name = txn.appName ?? String(txn.approvalProgram) + "-" + String(txn.clearProgram);
       deployer.assertNoAsset(name);
       const approval = await deployer.ensureCompiled(txn.approvalProgram);
       const clear = await deployer.ensureCompiled(txn.clearProgram);
@@ -161,7 +161,7 @@ async function mkTx (
       break;
     }
     case wtypes.TransactionType.UpdateApp: {
-      const cpKey = String(txn.newApprovalProgram) + "-" + String(txn.newClearProgram);
+      const cpKey = txn.appName ?? String(txn.newApprovalProgram) + "-" + String(txn.newClearProgram);
       const approval = await deployer.ensureCompiled(txn.newApprovalProgram);
       const clear = await deployer.ensureCompiled(txn.newClearProgram);
       txn.approvalProg = new Uint8Array(Buffer.from(approval.compiled, "base64"));

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -532,13 +532,16 @@ export interface Deployer {
    * @payFlags  Transaction Parameters
    * @scTmplParams  Smart contract template parameters
    *     (used only when compiling PyTEAL to TEAL)
+   * @appName name of the app to deploy. This name (if passed) will be used as
+   * the checkpoint "key", and app information will be stored agaisnt this name
    */
   deployApp: (
     approvalProgram: string,
     clearProgram: string,
     flags: rtypes.AppDeploymentFlags,
     payFlags: wtypes.TxParams,
-    scTmplParams?: SCParams) => Promise<rtypes.SSCInfo>
+    scTmplParams?: SCParams,
+    appName?: string) => Promise<rtypes.SSCInfo>
 
   /**
    * Update programs(approval, clear) for a stateful smart contract.
@@ -548,6 +551,8 @@ export interface Deployer {
    * @param newApprovalProgram New Approval Program filename
    * @param newClearProgram New Clear Program filename
    * @param flags Optional parameters to SSC (accounts, args..)
+   * @param appName name of the app to deploy. This name (if passed) will be used as
+   * the checkpoint "key", and app information will be stored agaisnt this name
    */
   updateApp: (
     sender: algosdk.Account,
@@ -555,7 +560,8 @@ export interface Deployer {
     appID: number,
     newApprovalProgram: string,
     newClearProgram: string,
-    flags: rtypes.AppOptionalFlags
+    flags: rtypes.AppOptionalFlags,
+    appName?: string
   ) => Promise<rtypes.SSCInfo>
 
   /**
@@ -625,6 +631,11 @@ export interface Deployer {
   /**
    * Queries a stateful smart contract info from checkpoint. */
   getApp: (nameApproval: string, nameClear: string) => rtypes.SSCInfo | undefined
+
+  /**
+   * Queries a stateful smart contract info from checkpoint name
+   * passed by user during deployment */
+  getAppByName: (appName: string) => rtypes.SSCInfo | undefined
 
   /**
    * Queries a delegated logic signature from checkpoint. */

--- a/packages/algob/test/lib/tx.ts
+++ b/packages/algob/test/lib/tx.ts
@@ -636,6 +636,30 @@ describe("Deploy, Delete transactions test in run mode", () => {
     assert.isUndefined(deployer.getApp("approval.teal", "clear.teal"));
   });
 
+  it("should deploy application in deploy mode and save info by name", async () => {
+    deployer = new DeployerDeployMode(deployerCfg);
+    const execParams: wtypes.ExecParams = {
+      type: wtypes.TransactionType.DeployApp,
+      sign: wtypes.SignType.SecretKey,
+      fromAccount: bobAcc,
+      approvalProgram: "approval.teal",
+      clearProgram: "clear.teal",
+      localInts: 1,
+      localBytes: 1,
+      globalInts: 1,
+      globalBytes: 1,
+      payFlags: {},
+      appName: "dao-app"
+    };
+    await executeTransaction(deployer, execParams);
+
+    // able to retrieve info by "appName"
+    assert.isDefined(deployer.getAppByName("dao-app"));
+
+    // do note that traditional way doesn't work if appName is passed
+    assert.isUndefined(deployer.getApp("approval.teal", "clear.teal"));
+  });
+
   it("should delete application in run mode", async () => {
     deployer = new DeployerDeployMode(deployerCfg);
     let execParams: wtypes.ExecParams = {

--- a/packages/algob/test/mocks/deployer.ts
+++ b/packages/algob/test/mocks/deployer.ts
@@ -81,6 +81,10 @@ export class FakeDeployer implements Deployer {
     throw new Error("Not implemented");
   }
 
+  getAppByName (appName: string): rtypes.SSCInfo | undefined {
+    throw new Error("Not implemented");
+  }
+
   getAppfromCPKey (key: string): rtypes.SSCInfo | undefined {
     throw new Error("Not implemented");
   }
@@ -142,7 +146,9 @@ export class FakeDeployer implements Deployer {
     approvalProgram: string,
     clearProgram: string,
     flags: rtypes.AppDeploymentFlags,
-    payFlags: wtypes.TxParams): Promise<rtypes.SSCInfo> {
+    payFlags: wtypes.TxParams,
+    scInitParam?: unknown,
+    appName?: string): Promise<rtypes.SSCInfo> {
     throw new Error("Not implemented");
   }
 
@@ -152,7 +158,8 @@ export class FakeDeployer implements Deployer {
     appID: number,
     newApprovalProgram: string,
     newClearProgram: string,
-    flags: rtypes.AppOptionalFlags
+    flags: rtypes.AppOptionalFlags,
+    appName?: string
   ): Promise<rtypes.SSCInfo> {
     throw new Error("Not implemented");
   }

--- a/packages/algob/test/stubs/algo-operator.ts
+++ b/packages/algob/test/stubs/algo-operator.ts
@@ -70,7 +70,8 @@ export class AlgoOperatorDryRunImpl implements AlgoOperator {
     flags: rtypes.AppDeploymentFlags,
     payFlags: wtypes.TxParams,
     txWriter: txWriter,
-    scInitParam?: unknown): Promise<rtypes.SSCInfo> {
+    scInitParam?: unknown,
+    appName?: string): Promise<rtypes.SSCInfo> {
     return {
       creator: String(flags.sender.addr) + "-get-address-dry-run",
       applicationAccount: MOCK_APPLICATION_ADDRESS,

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -168,6 +168,7 @@ export type DeployAppParam = BasicParams & AppOptionalFlags & {
   extraPages?: number
   approvalProg?: Uint8Array
   clearProg?: Uint8Array
+  appName?: string // name of app to store info against in checkpoint
 };
 
 export type UpdateAppParam = BasicParams & AppOptionalFlags & {
@@ -177,6 +178,7 @@ export type UpdateAppParam = BasicParams & AppOptionalFlags & {
   newClearProgram: string
   approvalProg?: Uint8Array
   clearProg?: Uint8Array
+  appName?: string // name of app to store info against in checkpoint
 };
 
 export type AppCallsParam = BasicParams & AppOptionalFlags & {


### PR DESCRIPTION
Closes #511

## Proposed Changes

+ Updated `deployer.deployApp()` & `deployer.updateApp()` to take one more optional parameter: `appName`.
+ Add `deployer.getAppByName`
+ Added `deployer.loadLogicFromCache`
