### PR TITLE
Fixbug on ItxnField opcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- Fixbug ItxnField not allow random address. Reported by @patrick
+- `Runtime` env is enforcing address use in ItxnField already `exist`. However, those addresses used in `acfg` or create asset transactions the addresses use for config may not exist. We fixed it in this [PR](https://github.com/scale-it/algo-builder/pull/550). Reported by @patrick
 
 ## v3.0.0 2021-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fixbug ItxnField not allow random address. Reported by @patrick
+
 ## v3.0.0 2021-12-22
 
 ### Improvements

--- a/packages/runtime/src/interpreter/opcode.ts
+++ b/packages/runtime/src/interpreter/opcode.ts
@@ -1,4 +1,6 @@
 /* eslint sonarjs/no-identical-functions: 0 */
+import { encodeAddress, isValidAddress } from "algosdk";
+
 import { RUNTIME_ERRORS } from "../errors/errors-list";
 import { RuntimeError } from "../errors/runtime-errors";
 import { GlobalFields, ITxArrFields, ITxnFields, MAX_UINT6, MAX_UINT8, MAX_UINT64, MAX_UINT128, MIN_UINT8, MIN_UINT64, TxArrFields, TxnFields } from "../lib/constants";
@@ -131,6 +133,20 @@ export class Op {
       });
     }
     return b;
+  }
+
+  /**
+   * asserts if given variable type is address
+   * @param a - value to assert (should in bytes)
+   * @param line - line number in TEAL file
+   */
+  assertAddress (a: unknown, line: number): Uint8Array {
+    const bytes = this.assertBytes(a, line);
+    const addr = encodeAddress(bytes);
+    if (!isValidAddress(addr)) {
+      throw new RuntimeError(RUNTIME_ERRORS.TEAL.INVALID_ADDR, { addr: a, line: line });
+    }
+    return bytes;
   }
 
   /**

--- a/packages/runtime/src/interpreter/opcode.ts
+++ b/packages/runtime/src/interpreter/opcode.ts
@@ -140,7 +140,7 @@ export class Op {
    * @param a - value to assert (should in bytes)
    * @param line - line number in TEAL file
    */
-  assertAddress (a: unknown, line: number): Uint8Array {
+  assertAlgorandAddress (a: unknown, line: number): Uint8Array {
     const bytes = this.assertBytes(a, line);
     const addr = encodeAddress(bytes);
     if (!isValidAddress(addr)) {

--- a/packages/runtime/src/lib/itxn.ts
+++ b/packages/runtime/src/lib/itxn.ts
@@ -65,9 +65,8 @@ export function setInnerTxField (
   }
 
   if (addrTxnFields.has(field)) {
-    const assertedVal = op.assertBytes(val, line);
-    const accountState = interpreter.getAccount(assertedVal, line);
-    txValue = Buffer.from(decodeAddress(accountState.address).publicKey);
+    const assertedAddr = op.assertAddress(val, line);
+    txValue = assertedAddr;
   }
 
   const encodedField = TxnFields[interpreter.tealVersion][field]; // eg 'rcv'
@@ -183,6 +182,14 @@ const _getRuntimeAccountAddr = (publickey: Buffer | undefined,
   return _getRuntimeAccount(publickey, interpreter, line)?.addr;
 };
 
+const _getASAConfigAddr = (addr?: Uint8Array): string => {
+  if (addr) {
+    return encodeAddress(addr);
+  }
+  // if addr not declare return ""
+  return "";
+};
+
 // parse encoded txn obj to execParams (params passed by user in algob)
 /* eslint-disable sonarjs/cognitive-complexity */
 export function parseEncodedTxnToExecParams (tx: EncTx,
@@ -240,10 +247,10 @@ export function parseEncodedTxnToExecParams (tx: EncTx,
         execParams.type = types.TransactionType.ModifyAsset;
         execParams.assetID = tx.caid;
         execParams.fields = {
-          manager: _getRuntimeAccountAddr(tx.apar?.m, interpreter, line) ?? "",
-          reserve: _getRuntimeAccountAddr(tx.apar?.r, interpreter, line) ?? "",
-          clawback: _getRuntimeAccountAddr(tx.apar?.c, interpreter, line) ?? "",
-          freeze: _getRuntimeAccountAddr(tx.apar?.f, interpreter, line) ?? ""
+          manager: _getASAConfigAddr(tx.apar?.m),
+          reserve: _getASAConfigAddr(tx.apar?.r),
+          clawback: _getASAConfigAddr(tx.apar?.c),
+          freeze: _getASAConfigAddr(tx.apar?.f)
         };
       } else { // if not delete or modify, it's ASA deployment
         execParams.type = types.TransactionType.DeployASA;
@@ -256,10 +263,10 @@ export function parseEncodedTxnToExecParams (tx: EncTx,
           unitName: tx.apar?.un,
           url: tx.apar?.au,
           metadataHash: tx.apar?.am,
-          manager: _getRuntimeAccountAddr(tx.apar?.m, interpreter, line),
-          reserve: _getRuntimeAccountAddr(tx.apar?.r, interpreter, line),
-          clawback: _getRuntimeAccountAddr(tx.apar?.c, interpreter, line),
-          freeze: _getRuntimeAccountAddr(tx.apar?.f, interpreter, line)
+          manager: _getASAConfigAddr(tx.apar?.m),
+          reserve: _getASAConfigAddr(tx.apar?.r),
+          clawback: _getASAConfigAddr(tx.apar?.c),
+          freeze: _getASAConfigAddr(tx.apar?.f)
         };
       }
       break;

--- a/packages/runtime/src/lib/itxn.ts
+++ b/packages/runtime/src/lib/itxn.ts
@@ -65,7 +65,7 @@ export function setInnerTxField (
   }
 
   if (addrTxnFields.has(field)) {
-    txValue = op.assertAddress(val, line);
+    txValue = op.assertAlgorandAddress(val, line);
   }
 
   const encodedField = TxnFields[interpreter.tealVersion][field]; // eg 'rcv'

--- a/packages/runtime/src/lib/itxn.ts
+++ b/packages/runtime/src/lib/itxn.ts
@@ -31,10 +31,13 @@ const byteTxnFields = new Set([
   'ConfigAssetMetadataHash', 'ConfigAssetURL'
 ]);
 
-const addrTxnFields = new Set([
+const acfgAddrTxnFields = new Set([
+  'ConfigAssetManager', 'ConfigAssetReserve', 'ConfigAssetFreeze', 'ConfigAssetClawback'
+]);
+
+const otherTxnFields = new Set([
   'Sender', 'Receiver', 'CloseRemainderTo', 'AssetSender', 'AssetCloseTo',
-  'AssetReceiver', 'FreezeAssetAccount', 'ConfigAssetManager',
-  'ConfigAssetReserve', 'ConfigAssetFreeze', 'ConfigAssetClawback'
+  'AssetReceiver', 'FreezeAssetAccount'
 ]);
 
 /**
@@ -64,7 +67,14 @@ export function setInnerTxField (
     txValue = convertToString(assertedVal);
   }
 
-  if (addrTxnFields.has(field)) {
+  if (otherTxnFields.has(field)) {
+    const assertedVal = op.assertBytes(val, line);
+    const accountState = interpreter.getAccount(assertedVal, line);
+    txValue = Buffer.from(decodeAddress(accountState.address).publicKey);
+  }
+
+  // if address use for acfg we only check address is valid
+  if (acfgAddrTxnFields.has(field)) {
     txValue = op.assertAlgorandAddress(val, line);
   }
 

--- a/packages/runtime/src/lib/itxn.ts
+++ b/packages/runtime/src/lib/itxn.ts
@@ -35,7 +35,7 @@ const acfgAddrTxnFields = new Set([
   'ConfigAssetManager', 'ConfigAssetReserve', 'ConfigAssetFreeze', 'ConfigAssetClawback'
 ]);
 
-const otherTxnFields = new Set([
+const otherAddrTxnFields = new Set([
   'Sender', 'Receiver', 'CloseRemainderTo', 'AssetSender', 'AssetCloseTo',
   'AssetReceiver', 'FreezeAssetAccount'
 ]);
@@ -67,7 +67,7 @@ export function setInnerTxField (
     txValue = convertToString(assertedVal);
   }
 
-  if (otherTxnFields.has(field)) {
+  if (otherAddrTxnFields.has(field)) {
     const assertedVal = op.assertBytes(val, line);
     const accountState = interpreter.getAccount(assertedVal, line);
     txValue = Buffer.from(decodeAddress(accountState.address).publicKey);

--- a/packages/runtime/src/lib/itxn.ts
+++ b/packages/runtime/src/lib/itxn.ts
@@ -65,8 +65,7 @@ export function setInnerTxField (
   }
 
   if (addrTxnFields.has(field)) {
-    const assertedAddr = op.assertAddress(val, line);
-    txValue = assertedAddr;
+    txValue = op.assertAddress(val, line);
   }
 
   const encodedField = TxnFields[interpreter.tealVersion][field]; // eg 'rcv'
@@ -186,7 +185,6 @@ const _getASAConfigAddr = (addr?: Uint8Array): string => {
   if (addr) {
     return encodeAddress(addr);
   }
-  // if addr not declare return ""
   return "";
 };
 

--- a/packages/runtime/test/fixtures/inner-transaction/assets/approval-asset-tx.py
+++ b/packages/runtime/test/fixtures/inner-transaction/assets/approval-asset-tx.py
@@ -188,9 +188,9 @@ def approval_program():
                 TxnField.config_asset_default_frozen: Int(1),
                 TxnField.config_asset_url: Txn.application_args[2],
                 TxnField.config_asset_manager: Global.current_application_address(),
-                TxnField.config_asset_reserve: Global.current_application_address(),
-                TxnField.config_asset_freeze: Global.current_application_address(),
-                TxnField.config_asset_clawback: Global.current_application_address(),
+                TxnField.config_asset_reserve: Txn.application_args[3],
+                TxnField.config_asset_freeze: Txn.application_args[3],
+                TxnField.config_asset_clawback: Txn.application_args[3],
             }
         ),
         InnerTxnBuilder.Submit(),

--- a/packages/runtime/test/integration/inner-transaction/asset-tx.ts
+++ b/packages/runtime/test/integration/inner-transaction/asset-tx.ts
@@ -409,7 +409,12 @@ describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[Asset Transfer, 
 
     const txParams = {
       ...appCallParams,
-      appArgs: ['str:deploy_asa_with_app_args', `str:asa_name`, `str:ipfs://ABCDEF`]
+      appArgs: [
+        'str:deploy_asa_with_app_args',
+        'str:asa_name',
+        'str:ipfs://ABCDEF',
+        `addr:${charlie.address}`
+      ]
     };
     runtime.executeTx(txParams);
     syncAccounts();
@@ -428,9 +433,9 @@ describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[Asset Transfer, 
     assert.equal(asaDef.unitName, "TEST");
     assert.equal(asaDef.url, "ipfs://ABCDEF");
     assert.equal(asaDef.manager, appAccount.address);
-    assert.equal(asaDef.reserve, appAccount.address);
-    assert.equal(asaDef.freeze, appAccount.address);
-    assert.equal(asaDef.clawback, appAccount.address);
+    assert.equal(asaDef.reserve, charlie.address);
+    assert.equal(asaDef.freeze, charlie.address);
+    assert.equal(asaDef.clawback, charlie.address);
 
     // verify ASA holding is set in creator account
     const creatorASAHolding = runtime.getAssetHolding(Number(createdAsaID), appAccount.address);

--- a/packages/runtime/test/integration/inner-transaction/asset-tx.ts
+++ b/packages/runtime/test/integration/inner-transaction/asset-tx.ts
@@ -16,6 +16,7 @@ describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[Asset Transfer, 
   let john = new AccountStore(minBalance + fee);
   let elon = new AccountStore(minBalance + fee);
   let bob = new AccountStore(minBalance + fee);
+  const charlie = new AccountStore(minBalance + fee); // random account - not exist in runtime env.
   let appAccount: AccountStoreI; // initialized later
 
   let runtime: Runtime;
@@ -347,11 +348,12 @@ describe("Algorand Smart Contracts(TEALv5) - Inner Transactions[Asset Transfer, 
     // assert ASA defined
     assert.isDefined(runtime.getAssetDef(assetID));
 
+    // charlie is random address and not external address on application
     const txParams = {
       ...appCallParams,
       appArgs: ['str:modify_asa'],
       foreignAssets: [assetID],
-      accounts: [elon.address, bob.address]
+      accounts: [elon.address, charlie.address]
     };
     runtime.executeTx(txParams);
     syncAccounts();

--- a/packages/runtime/test/src/interpreter/inner-transaction.ts
+++ b/packages/runtime/test/src/interpreter/inner-transaction.ts
@@ -440,7 +440,7 @@ describe("TEALv5: Inner Transactions", function () {
       expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
     });
 
-    it(`should fail: invalid ref, not an account`, function () {
+    it(`should fail: invalid ref, not a valid account address`, function () {
       // but a b32 string rep is not an account
       tealCode = `
         itxn_begin
@@ -448,6 +448,22 @@ describe("TEALv5: Inner Transactions", function () {
         itxn_field AssetCloseTo
       `;
       expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
+
+      // b31 => not vaild account
+      tealCode = `
+        itxn_begin
+        byte "0123456789012345678901234567890"
+        itxn_field AssetCloseTo
+      `;
+      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
+
+      // int number =>  invaild type (should be bytes)
+      tealCode = `
+        itxn_begin
+        int 9
+        itxn_field AssetCloseTo
+      `;
+      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_TYPE);
     });
 
     it(`should fail: not a uint64`, function () {

--- a/packages/runtime/test/src/interpreter/inner-transaction.ts
+++ b/packages/runtime/test/src/interpreter/inner-transaction.ts
@@ -384,19 +384,22 @@ describe("TEALv5: Inner Transactions", function () {
   });
 
   describe("TestFieldTypes", function () {
-    it('should pass: teal understand 32 bytes value is address', () => {
-      tealCode = `
+    const ConfigAddresses = ['ConfigAssetManager', 'ConfigAssetReserve', 'ConfigAssetFreeze', 'ConfigAssetClawback'];
+
+    it('should pass: teal understand 32 bytes value is address with acfg address', () => {
+      ConfigAddresses.forEach((configAddr) => {
+        tealCode = `
         itxn_begin
         byte "01234567890123456789012345678901"
-        itxn_field AssetReceiver
+        itxn_field ${configAddr}
         int 1
       `;
 
-      assert.doesNotThrow(() => executeTEAL(tealCode));
+        assert.doesNotThrow(() => executeTEAL(tealCode));
+      });
     });
 
-    it("should pass: use random address with asa config transaction", () => {
-      const ConfigAddresses = ['ConfigAssetManager', 'ConfigAssetReserve', 'ConfigAssetFreeze', 'ConfigAssetClawback'];
+    it("should pass: use random address with asa config transaction with acfg address", () => {
       ConfigAddresses.forEach((configAddress) => {
         tealCode = `
           itxn_begin           
@@ -416,7 +419,7 @@ describe("TEALv5: Inner Transactions", function () {
         byte "pay"
         itxn_field Sender
       `;
-      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
+      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.ADDR_NOT_VALID);
 
       tealCode = `
         itxn_begin
@@ -430,14 +433,14 @@ describe("TEALv5: Inner Transactions", function () {
         byte ""
         itxn_field CloseRemainderTo
       `;
-      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
+      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.ADDR_NOT_VALID);
 
       tealCode = `
         itxn_begin
         byte ""
         itxn_field AssetSender
       `;
-      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
+      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.ADDR_NOT_VALID);
     });
 
     it(`should fail: invalid ref, not a valid account address`, function () {
@@ -447,7 +450,7 @@ describe("TEALv5: Inner Transactions", function () {
         byte "GAYTEMZUGU3DOOBZGAYTEMZUGU3DOOBZGAYTEMZUGU3DOOBZGAYZIZD42E"
         itxn_field AssetCloseTo
       `;
-      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
+      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.ADDR_NOT_VALID);
 
       // b31 => not vaild account
       tealCode = `
@@ -455,7 +458,7 @@ describe("TEALv5: Inner Transactions", function () {
         byte "0123456789012345678901234567890"
         itxn_field AssetCloseTo
       `;
-      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
+      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.ADDR_NOT_VALID);
 
       // int number =>  invaild type (should be bytes)
       tealCode = `

--- a/packages/runtime/test/src/interpreter/inner-transaction.ts
+++ b/packages/runtime/test/src/interpreter/inner-transaction.ts
@@ -390,7 +390,7 @@ describe("TEALv5: Inner Transactions", function () {
         byte "pay"
         itxn_field Sender
       `;
-      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.ADDR_NOT_VALID);
+      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
 
       tealCode = `
         itxn_begin
@@ -404,33 +404,35 @@ describe("TEALv5: Inner Transactions", function () {
         byte ""
         itxn_field CloseRemainderTo
       `;
-      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.ADDR_NOT_VALID);
+      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
 
       tealCode = `
         itxn_begin
         byte ""
         itxn_field AssetSender
       `;
-      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.ADDR_NOT_VALID);
+      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
     });
 
-    it(`should fail: invalid ref, not an account`, function () {
-      // can't really tell if it's an addres, so 32 bytes gets further
+    it('should pass: teal understand 32 bytes value is address', () => {
       tealCode = `
         itxn_begin
         byte "01234567890123456789012345678901"
         itxn_field AssetReceiver
+        int 1
       `;
-      expectRuntimeError(() => executeTEAL(tealCode),
-        RUNTIME_ERRORS.TEAL.ADDR_NOT_FOUND_IN_TXN_ACCOUNT);
 
+      assert.doesNotThrow(() => executeTEAL(tealCode));
+    });
+
+    it(`should fail: invalid ref, not an account`, function () {
       // but a b32 string rep is not an account
       tealCode = `
         itxn_begin
         byte "GAYTEMZUGU3DOOBZGAYTEMZUGU3DOOBZGAYTEMZUGU3DOOBZGAYZIZD42E"
         itxn_field AssetCloseTo
       `;
-      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.ADDR_NOT_VALID);
+      expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
     });
 
     it(`should fail: not a uint64`, function () {

--- a/packages/runtime/test/src/interpreter/inner-transaction.ts
+++ b/packages/runtime/test/src/interpreter/inner-transaction.ts
@@ -384,6 +384,32 @@ describe("TEALv5: Inner Transactions", function () {
   });
 
   describe("TestFieldTypes", function () {
+    it('should pass: teal understand 32 bytes value is address', () => {
+      tealCode = `
+        itxn_begin
+        byte "01234567890123456789012345678901"
+        itxn_field AssetReceiver
+        int 1
+      `;
+
+      assert.doesNotThrow(() => executeTEAL(tealCode));
+    });
+
+    it("should pass: use random address with asa config transaction", () => {
+      const ConfigAddresses = ['ConfigAssetManager', 'ConfigAssetReserve', 'ConfigAssetFreeze', 'ConfigAssetClawback'];
+      ConfigAddresses.forEach((configAddress) => {
+        tealCode = `
+          itxn_begin           
+          addr KW5MRCMF4ICRW32EQFHJJQXF6O6DIXHD4URTXPD657B6QTQA3LWZSLJEUY
+          itxn_field ${configAddress}
+          int acfg
+          itxn_field TypeEnum
+          int 1
+        `;
+        assert.doesNotThrow(() => executeTEAL(tealCode));
+      });
+    });
+
     it(`should fail: not an address`, function () {
       tealCode = `
         itxn_begin
@@ -412,17 +438,6 @@ describe("TEALv5: Inner Transactions", function () {
         itxn_field AssetSender
       `;
       expectRuntimeError(() => executeTEAL(tealCode), RUNTIME_ERRORS.TEAL.INVALID_ADDR);
-    });
-
-    it('should pass: teal understand 32 bytes value is address', () => {
-      tealCode = `
-        itxn_begin
-        byte "01234567890123456789012345678901"
-        itxn_field AssetReceiver
-        int 1
-      `;
-
-      assert.doesNotThrow(() => executeTEAL(tealCode));
     });
 
     it(`should fail: invalid ref, not an account`, function () {


### PR DESCRIPTION
## Proposed Changes

+ Allow random address when creating asset and re-config when using the Inner transaction.
+ Teal ItxnField opcode understands address 32 bytes so add tests for this case. 

