### PR TITLE
Algobpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * `getCompiledASC`: compiles a contract in real time, returns info after compilation (eg. bytecode, bytecode hash, timestamp etc).
   * `getDeployedASC`: returns cached program (in artifacts/cache) compiled info(bytecode, hash, filename etc).
 - Added `sandbox-up-dev` and `sandbox-reset` commands into Makefile in `infrastructure/`.
-
+- Use strict parsing rules when decoding PyTEAL teamplate parameters using `algobpy`. Previously, on decode failure, the script was continuing with partially update template params, now we fail with an exception.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * `getCompiledASC`: compiles a contract in real time, returns info after compilation (eg. bytecode, bytecode hash, timestamp etc).
   * `getDeployedASC`: returns cached program (in artifacts/cache) compiled info(bytecode, hash, filename etc).
 - Added `sandbox-up-dev` and `sandbox-reset` commands into Makefile in `infrastructure/`.
-- Use strict parsing rules when decoding PyTEAL teamplate parameters using `algobpy`. Previously, on decode failure, the script was continuing with partially update template params, now we fail with an exception.
+- Use strict parsing rules when decoding PyTEAL teamplate parameters using `algobpy`. Previously, on decode failure, the script was continuing with partially updated template params, now we fail with an exception.
 
 ### Bug Fixes
 

--- a/examples/algobpy/parse.py
+++ b/examples/algobpy/parse.py
@@ -1,17 +1,15 @@
-import sys
 import yaml
 
-'''
-Overwrites scParam values if args is defined and has keys common from scParam
-'''
+
 def parse_params(args, scParam):
-    
-    # decode external parameter and update current values.
-    # (if an external paramter is passed)
+    '''
+    Decodes external template parameters and overwrites the default values.
+    '''
     try:
         param = yaml.safe_load(args)
         for key, value in param.items():
             scParam[key] = value
         return scParam
     except yaml.YAMLError as exc:
-        print(exc)
+        print("CAN'T LOAD CUSTOM TEMPLATE PARARMETERS")
+        raise exc


### PR DESCRIPTION
Use strict parsing rules when decoding PyTEAL teamplate parameters using `algobpy`. Previously, on decode failure, the script was continuing with partially update template params, now we fail with an exception.

