### PR TITLE
Get compiled asc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Improvements
 
 - Added following functions in `deployer` API
-  * `getCompiledASC`: compiles a contract in real time, returns info after compilation (eg. bytecode, bytecode hash, timestamp etc).
-  * `getDeployedASC`: returns cached program (in artifacts/cache) compiled info(bytecode, hash, filename etc).
+  * `compileASC`: alias to `deloyer.ensureCompiled`. The latter is now marked deprecated and `compileASC` should be used instead.
+  * `getDeployedASC`: returns cached program (from artifacts/cache) `ASCCache` object.
 - Added `sandbox-up-dev` and `sandbox-reset` commands into Makefile in `infrastructure/`.
 - Use strict parsing rules when decoding PyTEAL teamplate parameters using `algobpy`. Previously, on decode failure, the script was continuing with partially updated template params, now we fail with an exception.
 

--- a/docs/guide/deployer.md
+++ b/docs/guide/deployer.md
@@ -170,11 +170,11 @@ You can learn more about Stateless Smart Contracts [here](https://developer.algo
 
 #### Compile contracts
 
-You can use the deployer API to compile smart contracts and get the contract's bytecode, hash, compilation timestamp etc:
-  * `getCompiledASC`: compiles a contract in real time, returns info after compilation (eg. bytecode, bytecode hash, timestamp etc).Eg.
+You can use the deployer API to compile smart contracts (ASC) and get the contract's bytecode, hash, compilation timestamp etc:
+  * `compiledASC`: compiles a contract in real time, returns `ASCCache` object. Example:
   ```js
-  const info = await deployer.getCompiledASC('buyback-lsig.py', { ARG_DAO_APP_ID: 23 });
+  const info = await deployer.compileASC('buyback-lsig.py', { ARG_DAO_APP_ID: 23 }, false);
   const bytecode = info.compiled;
   ```
 
-  * `getDeployedASC`: Similar to above, but instead of compiling in real time, it returns cached program (in artifacts/cache) compiled info(bytecode, hash, filename etc).
+  * `getDeployedASC`: Similar to above, but instead of compiling, it returns cached program (from artifacts/cache) by deployment name. 

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -10,7 +10,7 @@ import * as algosdk from "algosdk";
 
 import { txWriter } from "../internal/tx-log-writer";
 import { AlgoOperator } from "../lib/algo-operator";
-import { CompileOp, getBytecodeAndHash } from "../lib/compile";
+import { CompileOp } from "../lib/compile";
 import { getDummyLsig, getLsig, getLsigFromCache } from "../lib/lsig";
 import { blsigExt, loadBinaryLsig, readMsigFromFile } from "../lib/msig";
 import { CheckpointFunctionsImpl, persistCheckpoint } from "../lib/script-checkpoints";
@@ -205,21 +205,35 @@ class DeployerBasicMode {
   }
 
   /**
-   * Complies program in real time, and returns compiled info (bytecode, hash, filename etc).
-   * @param name ASC name
-   * @param scTmplParams: Smart contract template parameters (used only when compiling PyTEAL to TEAL)
+   * Alias to `this.compileASC` with last two parameters being swapped.
+   * Deprecated: this function will be removed in the next release.
    */
-  async getCompiledASC (name: string, scTmplParams?: SCParams): Promise<ASCCache> {
-    return await getBytecodeAndHash(name, this.algoOp.algodClient, scTmplParams);
+  ensureCompiled (
+    name: string,
+    force?: boolean,
+    scTmplParams?: SCParams
+  ): Promise<ASCCache> {
+    return this.compileASC(name, force, scTmplParams);
   }
 
   /**
-   * Returns cached program (in artifacts/cache) compiled info(bytecode, hash, filename etc).
-   * @param name ASC file name
+   * Returns ASCCache (with compiled code)
+   * @param name: Smart Contract filename (must be present in assets folder)
+   * @param scTmplParams: scTmplParams: Smart contract template parameters
+   *     (used only when compiling PyTEAL to TEAL)
+   * @param force: if force is true file will be compiled for sure, even if it's checkpoint exist
    */
-  async getDeployedASC (name: string): Promise<ASCCache | undefined> {
+  compileASC (name: string, scTmplParams?: SCParams, force?: boolean): Promise<ASCCache> {
+    return this.algoOp.ensureCompiled(name, force, scTmplParams);
+  }
+
+  /**
+   * Returns cached program (from artifacts/cache) `ASCCache` object by deployment name.
+   * @param name ASC name used during deployment
+   */
+  getDeployedASC (name: string): Promise<ASCCache | undefined> {
     const op = new CompileOp(this.algoOp.algodClient);
-    return await op.readArtifact(name);
+    return op.readArtifact(name);
   }
 
   /**
@@ -242,8 +256,8 @@ class DeployerBasicMode {
    * Send signed transaction to network and wait for confirmation
    * @param rawTxns Signed Transaction(s)
    */
-  async sendAndWait (rawTxns: Uint8Array | Uint8Array[]): Promise<ConfirmedTxInfo> {
-    return await this.algoOp.sendAndWait(rawTxns);
+  sendAndWait (rawTxns: Uint8Array | Uint8Array[]): Promise<ConfirmedTxInfo> {
+    return this.algoOp.sendAndWait(rawTxns);
   }
 
   /**
@@ -253,7 +267,7 @@ class DeployerBasicMode {
    * @param accountName
    * @param flags Transaction flags
    */
-  async optInAccountToASA (
+  optInAccountToASA (
     asa: string,
     accountName: string,
     flags: wtypes.TxParams
@@ -274,7 +288,7 @@ class DeployerBasicMode {
       }
       asaId = Number(asa);
     }
-    await this.algoOp.optInAccountToASA(asa, asaId, this._getAccount(accountName), flags);
+    return this.algoOp.optInAccountToASA(asa, asaId, this._getAccount(accountName), flags);
   }
 
   /**
@@ -284,7 +298,7 @@ class DeployerBasicMode {
    * @param lsig logic signature
    * @param flags Transaction flags
    */
-  async optInLsigToASA (
+  optInLsigToASA (
     asa: string,
     lsig: LogicSigAccount,
     flags: wtypes.TxParams
@@ -306,7 +320,7 @@ class DeployerBasicMode {
       }
       asaId = Number(asa);
     }
-    await this.algoOp.optInLsigToASA(asa, asaId, lsig, flags);
+    return this.algoOp.optInLsigToASA(asa, asaId, lsig, flags);
   }
 
   /**
@@ -317,7 +331,7 @@ class DeployerBasicMode {
    * @param payFlags Transaction flags
    * @param flags Optional parameters to SSC (accounts, args..)
    */
-  async optInAccountToApp (
+  optInAccountToApp (
     sender: rtypes.Account,
     appID: number,
     payFlags: wtypes.TxParams,
@@ -330,7 +344,7 @@ class DeployerBasicMode {
       appID: appID,
       payFlags: {}
     });
-    await this.algoOp.optInAccountToApp(sender, appID, payFlags, flags);
+    return this.algoOp.optInAccountToApp(sender, appID, payFlags, flags);
   }
 
   /**
@@ -341,7 +355,7 @@ class DeployerBasicMode {
    * @param payFlags Transaction flags
    * @param flags Optional parameters to SSC (accounts, args..)
    */
-  async optInLsigToApp (
+  optInLsigToApp (
     appID: number,
     lsig: LogicSigAccount,
     payFlags: wtypes.TxParams,
@@ -355,22 +369,7 @@ class DeployerBasicMode {
       appID: appID,
       payFlags: {}
     });
-    await this.algoOp.optInLsigToApp(appID, lsig, payFlags, flags);
-  }
-
-  /**
-   * Returns ASCCache (with compiled code)
-   * @param name: Smart Contract filename (must be present in assets folder)
-   * @param force: if force is true file will be compiled for sure, even if it's checkpoint exist
-   * @param scTmplParams: scTmplParams: Smart contract template parameters
-   *     (used only when compiling PyTEAL to TEAL)
-   */
-  async ensureCompiled (
-    name: string,
-    force?: boolean,
-    scTmplParams?: SCParams
-  ): Promise<ASCCache> {
-    return await this.algoOp.ensureCompiled(name, force, scTmplParams);
+    return this.algoOp.optInLsigToApp(appID, lsig, payFlags, flags);
   }
 
   /**
@@ -699,7 +698,7 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
    * @param scTmplParams: scTmplParams: Smart contract template parameters
    *     (used only when compiling PyTEAL to TEAL)
    * @param appName name of the app to deploy. This name (if passed) will be used as
-   * the checkpoint "key", and app information will be stored agaisnt this name
+   * the checkpoint "key", and app information will be associated with this name
    */
   async deployApp (
     approvalProgram: string,
@@ -744,7 +743,7 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
    * @param scTmplParams: scTmplParams: Smart contract template parameters
    *     (used only when compiling PyTEAL to TEAL)
    * @param appName name of the app to deploy. This name (if passed) will be used as
-   * the checkpoint "key", and app information will be stored agaisnt this name
+   * the checkpoint "key", and app information will be associated with this name
    */
   async updateApp (
     sender: algosdk.Account,

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -228,7 +228,8 @@ class DeployerBasicMode {
   }
 
   /**
-   * Returns cached program (from artifacts/cache) `ASCCache` object by deployment name.
+   * Returns cached program (from artifacts/cache) `ASCCache` object by filename.
+   * TODO: beta support - this will change
    * @param name ASC name used during deployment
    */
   getDeployedASC (name: string): Promise<ASCCache | undefined> {

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -213,7 +213,7 @@ class DeployerBasicMode {
     force?: boolean,
     scTmplParams?: SCParams
   ): Promise<ASCCache> {
-    return this.compileASC(name, force, scTmplParams);
+    return this.compileASC(name, scTmplParams, force);
   }
 
   /**

--- a/packages/algob/src/lib/compile.ts
+++ b/packages/algob/src/lib/compile.ts
@@ -34,7 +34,7 @@ export class CompileOp {
    */
   async ensureCompiled (filename: string, force?: boolean, scTmplParams?: SCParams):
   Promise<ASCCache | PyASCCache> {
-    const filePath = getPathFromDirRecursive(ASSETS_DIR, filename) as string;
+    const filePath = getPathFromDirRecursive(ASSETS_DIR, filename);
 
     if (force === undefined) {
       force = false;
@@ -116,19 +116,4 @@ export class CompileOp {
   writeFile (filename: string, content: string): void {
     fs.writeFileSync(filename, content);
   }
-}
-
-/**
- * Retuns compiled program info (bytecode, hash, filename etc)
- * @param name : ASC filename
- * @param algodClient : algodClient
- * @param scTmplParams: Smart contract template parameters (used only when compiling PyTEAL to TEAL)
- */
-export async function getBytecodeAndHash (
-  name: string,
-  algodClient: Algodv2,
-  scTmplParams?: SCParams): Promise<ASCCache> {
-  const compileOp = new CompileOp(algodClient);
-  const result: ASCCache = await compileOp.ensureCompiled(name, false, scTmplParams);
-  return result;
 }

--- a/packages/algob/src/lib/compile.ts
+++ b/packages/algob/src/lib/compile.ts
@@ -1,5 +1,5 @@
-import { getPathFromDirRecursive, PyCompileOp } from "@algo-builder/runtime";
-import { parseAlgorandError, types } from "@algo-builder/web";
+import { ERRORS, getPathFromDirRecursive, PyCompileOp } from "@algo-builder/runtime";
+import { BuilderError, parseAlgorandError, types } from "@algo-builder/web";
 import type { Algodv2, modelsv2 } from "algosdk";
 import * as fs from 'fs';
 import * as murmurhash from 'murmurhash';
@@ -34,14 +34,18 @@ export class CompileOp {
    */
   async ensureCompiled (filename: string, force?: boolean, scTmplParams?: SCParams):
   Promise<ASCCache | PyASCCache> {
-    const filePath = getPathFromDirRecursive(ASSETS_DIR, filename);
-
+    if (!filename.endsWith(tealExt) && !filename.endsWith(lsigExt) && !filename.endsWith(pyExt)) {
+      throw new Error(`filename "${filename}" must end with "${tealExt}" or "${lsigExt}" or "${pyExt}"`); // TODO: convert to buildererror
+    }
     if (force === undefined) {
       force = false;
     }
 
-    if (!filename.endsWith(tealExt) && !filename.endsWith(lsigExt) && !filename.endsWith(pyExt)) {
-      throw new Error(`filename "${filename}" must end with "${tealExt}" or "${lsigExt}" or "${pyExt}"`); // TODO: convert to buildererror
+    const filePath = getPathFromDirRecursive(ASSETS_DIR, filename);
+    if (filePath === undefined) {
+      throw new BuilderError(ERRORS.GENERAL.FILE_NOT_FOUND_IN_DIR, {
+        directory: ASSETS_DIR, file: filename
+      });
     }
 
     let teal: string;

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -653,24 +653,23 @@ export interface Deployer {
   loadLogic: (name: string, scTmplParams?: SCParams) => Promise<LogicSigAccount>
 
   /**
-   * Returns ASCCache (with compiled code)
-   * @name  Smart Contract filename (must be present in assets folder)
-   * @force  if force is true file will be compiled for sure, even if it's checkpoint exist
-   * @scTmplParams  scTmplParams: Smart contract template parameters
-   *     (used only when compiling PyTEAL to TEAL)
+   * Alias to `this.compileASC`
+   * Deprecated: this function will be removed in the next release.
    */
   ensureCompiled: (name: string, force?: boolean, scTmplParams?: SCParams) => Promise<ASCCache>
 
   /**
-   * Returns program compiled info: bytecode (compiled program) and it's hash.
-   * @param name ASC name
-   * @param scTmplParams: Smart contract template parameters (used only when compiling PyTEAL to TEAL)
+   * Returns ASCCache (with compiled code)
+   * @param name: Smart Contract filename (must be present in assets folder)
+   * @param scTmplParams: scTmplParams: Smart contract template parameters
+   *     (used only when compiling PyTEAL to TEAL)
+   * @param force: if force is true file will be compiled for sure, even if it's checkpoint exist
    */
-  getCompiledASC: (name: string, scTmplParams?: SCParams) => Promise<ASCCache>
+  compileASC: (name: string, scTmplParams?: SCParams, force?: boolean) => Promise<ASCCache>
 
   /**
-   * Returns cached program (in artifacts/cache) compiled info(bytecode, hash, filename etc).
-   * @param name ASC file name
+   * Returns cached program (from artifacts/cache) `ASCCache` object by deployment name.
+   * @param name ASC name used during deployment
    */
   getDeployedASC: (name: string) => Promise<ASCCache | undefined>
 

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -668,7 +668,8 @@ export interface Deployer {
   compileASC: (name: string, scTmplParams?: SCParams, force?: boolean) => Promise<ASCCache>
 
   /**
-   * Returns cached program (from artifacts/cache) `ASCCache` object by deployment name.
+   * Returns cached program (from artifacts/cache) `ASCCache` object by filename.
+   * TODO: beta support - this will change
    * @param name ASC name used during deployment
    */
   getDeployedASC: (name: string) => Promise<ASCCache | undefined>

--- a/packages/algob/test/mocks/deployer.ts
+++ b/packages/algob/test/mocks/deployer.ts
@@ -13,7 +13,7 @@ import type {
 } from "../../src/types";
 
 export class FakeDeployer implements Deployer {
-  asa = new Map<string, rtypes. ASAInfo>();
+  asa = new Map<string, rtypes.ASAInfo>();
   ssc = new Map<string, rtypes.SSCInfo>();
   lsig = new Map<string, LsigInfo>();
   isDeployMode = false;
@@ -121,8 +121,12 @@ export class FakeDeployer implements Deployer {
     throw new Error("Not implemented");
   };
 
-  async getCompiledASC (name: string,
-    scTmplParams?: SCParams): Promise<ASCCache> {
+  async ensureCompiled (name: string, force?: boolean, scInitParam?: unknown): Promise<ASCCache> {
+    throw new Error("Not implemented");
+  }
+
+  async compileASC (name: string,
+    scTmplParams?: SCParams, force?: boolean): Promise<ASCCache> {
     throw new Error("Not implemented");
   }
 
@@ -172,10 +176,6 @@ export class FakeDeployer implements Deployer {
     scTmplParams?: SCParams,
     appName?: string
   ): Promise<rtypes.SSCInfo> {
-    throw new Error("Not implemented");
-  }
-
-  async ensureCompiled (name: string, force?: boolean, scInitParam?: unknown): Promise<ASCCache> {
     throw new Error("Not implemented");
   }
 

--- a/packages/runtime/src/errors/errors-list.ts
+++ b/packages/runtime/src/errors/errors-list.ts
@@ -1,14 +1,8 @@
-export const RUNTIME_ERROR_PREFIX = "RUNTIME_ERR";
-
 export interface ErrorDescriptor {
   number: number
   message: string
   title: string
   description: string
-}
-
-export function getRuntimeErrorCode (error: ErrorDescriptor): string {
-  return `${RUNTIME_ERROR_PREFIX}${error.number}`;
 }
 
 export const RUNTIME_ERROR_RANGES = {
@@ -20,7 +14,7 @@ export const RUNTIME_ERROR_RANGES = {
 
 export const PARSE_ERROR = "Parse Error";
 
-export const tealErrors = {
+const tealErrors = {
   ASSERT_STACK_LENGTH: {
     number: 1000,
     message: "Length of stack is less than min length required for current op at line %line%",
@@ -354,7 +348,7 @@ maximun uint128`
   }
 };
 
-export const runtimeGeneralErrors = {
+const runtimeGeneralErrors = {
   LOGIC_SIGNATURE_NOT_FOUND: {
     number: 1300,
     message: "logic signature not found",
@@ -459,7 +453,7 @@ export const runtimeGeneralErrors = {
   }
 };
 
-export const transactionErrors = {
+const transactionErrors = {
   TRANSACTION_TYPE_ERROR: {
     number: 1400,
     message: "Error. Transaction Type %transaction% is Unknown",
@@ -505,7 +499,7 @@ export const transactionErrors = {
   }
 };
 
-export const runtimeAsaErrors = {
+const runtimeAsaErrors = {
   PARAM_PARSE_ERROR: {
     number: 1500,
     message: `Invalid ASA definition: '%source%'.
@@ -590,3 +584,5 @@ export const RUNTIME_ERRORS: {
   TRANSACTION: transactionErrors,
   ASA: runtimeAsaErrors
 };
+
+export default RUNTIME_ERRORS;

--- a/packages/runtime/src/errors/runtime-errors.ts
+++ b/packages/runtime/src/errors/runtime-errors.ts
@@ -1,7 +1,12 @@
 import { applyErrorMessageTemplate } from "@algo-builder/web";
 
 import { AnyMap } from "../types";
-import { ErrorDescriptor, getRuntimeErrorCode } from "./errors-list";
+import { ErrorDescriptor } from "./errors-list";
+
+export const RUNTIME_ERROR_PREFIX = "RUNTIME_ERR";
+function getRuntimeErrorCode (error: ErrorDescriptor): string {
+  return `${RUNTIME_ERROR_PREFIX}${error.number}`;
+}
 
 export class RuntimeError extends Error {
   public static isRuntimeError(other: any): other is RuntimeError { // eslint-disable-line

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,5 @@
 import { AccountStore } from "./account";
-import * as ERRORS from "./errors/errors-list";
+import ERRORS from "./errors/errors-list";
 import { parseZodError } from "./errors/validation-errors";
 import { Interpreter } from "./interpreter/interpreter";
 import { getProgram } from "./lib//load-program";


### PR DESCRIPTION
Closes #x

## Proposed Changes

+ renamed `getCompiledASC` to `compileASC` - it's shorter an more clear. Also reuse the `ensureCompiled`.
+ deprecate `ensureCompiled` in favor of `compileASC`
+ remove useless async/ await - if no need to wait in the middle of a function we can return promise directly.
