### PR TITLE
save tealCode in ASCCache as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Changed:
 - `printLocalStateSCC` renamed to `printLocalStateApp`.
 - `printGlobalStateSCC` renamed to `printGlobalStateApp`.
 
+- The `compile.ts` has been updated and now the tealCode is stored in cache when `scTmplParams` are used to compile TEAL with hardcoded params.
+- The ` PyASCCache` has been merged to `ASCCache` and is not used anymore. 
+
+
 ### Features
 
 - Used app account instead of `deposit_lsig` in `examples/dao`

--- a/packages/algob/src/lib/compile.ts
+++ b/packages/algob/src/lib/compile.ts
@@ -8,7 +8,7 @@ import YAML from "yaml";
 
 import { assertDir, ASSETS_DIR, CACHE_DIR } from "../internal/core/project-structure";
 import { timestampNow } from "../lib/time";
-import type { ASCCache, PyASCCache, SCParams } from "../types";
+import type { ASCCache, SCParams } from "../types";
 
 export const tealExt = ".teal";
 export const pyExt = ".py";
@@ -33,7 +33,7 @@ export class CompileOp {
    * @param scTmplParams: Smart contract template parameters (used only when compiling PyTEAL to TEAL)
    */
   async ensureCompiled (filename: string, force?: boolean, scTmplParams?: SCParams):
-  Promise<ASCCache | PyASCCache> {
+  Promise<ASCCache> {
     if (!filename.endsWith(tealExt) && !filename.endsWith(lsigExt) && !filename.endsWith(pyExt)) {
       throw new Error(`filename "${filename}" must end with "${tealExt}" or "${lsigExt}" or "${pyExt}"`); // TODO: convert to buildererror
     }
@@ -98,7 +98,7 @@ export class CompileOp {
     return this.algocl.compile(code).do();
   }
 
-  async compile (filename: string, tealCode: string, tealHash: number): Promise<ASCCache | PyASCCache> {
+  async compile (filename: string, tealCode: string, tealHash: number): Promise<ASCCache> {
     try {
       const co = await this.callCompiler(tealCode);
       return {

--- a/packages/algob/src/lib/compile.ts
+++ b/packages/algob/src/lib/compile.ts
@@ -101,16 +101,16 @@ export class CompileOp {
   async compile (filename: string, tealCode: string, tealHash: number): Promise<ASCCache | PyASCCache> {
     try {
       const co = await this.callCompiler(tealCode);
-      const result = {
+      return {
         filename: filename,
         timestamp: timestampNow(),
         compiled: co.result,
         compiledHash: co.hash,
         srcHash: tealHash,
         // compiled base64 converted into bytes
-        base64ToBytes: new Uint8Array(Buffer.from(co.result, "base64"))
+        base64ToBytes: new Uint8Array(Buffer.from(co.result, "base64")),
+        tealCode: tealCode
       };
-      return filename.endsWith(pyExt) ? { ...result, tealCode: tealCode } : result;
     } catch (e) {
       if (types.isRequestError(e)) { throw parseAlgorandError(e, { filename: filename }); }
       throw e;

--- a/packages/algob/src/lib/dryrun.ts
+++ b/packages/algob/src/lib/dryrun.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import { writeToFile } from "../builtin-tasks/gen-accounts";
 import { ASSETS_DIR, CACHE_DIR } from "../internal/core/project-structure";
 import { timestampNow } from "../lib/time";
-import type { DebuggerContext, Deployer, PyASCCache } from "../types";
+import type { ASCCache, DebuggerContext, Deployer } from "../types";
 import { makeAndSignTx } from "./tx";
 
 export const tealExt = ".teal";
@@ -209,8 +209,8 @@ export class Tealdbg {
 
         // load pyCache from "artifacts/cache"
         if (fs.existsSync(path.join(CACHE_DIR, file + ".yaml"))) {
-          const pathToPyCache = getPathFromDirRecursive(CACHE_DIR, file + ".yaml") as string;
-          const pyCache = loadFromYamlFileSilent(pathToPyCache) as PyASCCache;
+          const pathToPyCache = getPathFromDirRecursive(CACHE_DIR, file + ".yaml");
+          const pyCache = loadFromYamlFileSilent(pathToPyCache) as ASCCache;
           tealFromPyTEAL = pyCache.tealCode;
         }
 
@@ -227,7 +227,7 @@ export class Tealdbg {
         }
         this.writeFile(pathToFile, tealFromPyTEAL);
       } else {
-        pathToFile = getPathFromDirRecursive(ASSETS_DIR, file) as string;
+        pathToFile = getPathFromDirRecursive(ASSETS_DIR, file);
       }
 
       tealdbgArgs.push(pathToFile);

--- a/packages/algob/src/lib/dryrun.ts
+++ b/packages/algob/src/lib/dryrun.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import { writeToFile } from "../builtin-tasks/gen-accounts";
 import { ASSETS_DIR, CACHE_DIR } from "../internal/core/project-structure";
 import { timestampNow } from "../lib/time";
-import type { ASCCache, DebuggerContext, Deployer } from "../types";
+import type { DebuggerContext, Deployer, ASCCache } from "../types";
 import { makeAndSignTx } from "./tx";
 
 export const tealExt = ".teal";
@@ -209,7 +209,7 @@ export class Tealdbg {
 
         // load pyCache from "artifacts/cache"
         if (fs.existsSync(path.join(CACHE_DIR, file + ".yaml"))) {
-          const pathToPyCache = getPathFromDirRecursive(CACHE_DIR, file + ".yaml");
+          const pathToPyCache = getPathFromDirRecursive(CACHE_DIR, file + ".yaml") as string;
           const pyCache = loadFromYamlFileSilent(pathToPyCache) as ASCCache;
           tealFromPyTEAL = pyCache.tealCode;
         }
@@ -227,7 +227,7 @@ export class Tealdbg {
         }
         this.writeFile(pathToFile, tealFromPyTEAL);
       } else {
-        pathToFile = getPathFromDirRecursive(ASSETS_DIR, file);
+        pathToFile = getPathFromDirRecursive(ASSETS_DIR, file) as string;
       }
 
       tealdbgArgs.push(pathToFile);

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -723,15 +723,12 @@ export interface ASCCache {
   compiledHash: string // hash returned by the compiler
   srcHash: number // source code hash
   base64ToBytes: Uint8Array // compiled base64 in bytes
+  tealCode: string
 }
 
 export interface AppCache {
   approval: ASCCache | undefined
   clear: ASCCache | undefined
-}
-
-export interface PyASCCache extends ASCCache {
-  tealCode: string
 }
 
 // ************************

--- a/packages/algob/test/builtin-tasks/compile.ts
+++ b/packages/algob/test/builtin-tasks/compile.ts
@@ -10,7 +10,7 @@ import YAML from 'yaml';
 import { compile } from "../../src/builtin-tasks/compile";
 import { ASSETS_DIR } from "../../src/internal/core/project-structure";
 import { CompileOp } from "../../src/lib/compile";
-import type { ASCCache, PyASCCache } from "../../src/types";
+import type { ASCCache } from "../../src/types";
 import { useFixtureProjectCopy } from "../helpers/project";
 
 interface CompileIn {
@@ -23,7 +23,7 @@ class CompileOpMock extends CompileOp {
   compiledFiles = [] as CompileIn[];
   writtenFiles = [] as string[];
 
-  async compile (filename: string, _tealCode: string, tealHash: number): Promise<ASCCache | PyASCCache> {
+  async compile (filename: string, _tealCode: string, tealHash: number): Promise<ASCCache> {
     this.compiledFiles.push({ filename, tealHash });
     this.timestamp++;
     return {
@@ -124,7 +124,7 @@ describe("Compile task", () => {
     assert.deepEqual(content.toString(), res);
   });
 
-  it("should return correct PyASCCache from CompileOp", async () => {
+  it("should return correct ASCCache from CompileOp", async () => {
     const result = await op.ensureCompiled(f3PY, true);
     const expected = fs.readFileSync(path.join(ASSETS_DIR, 'gold-asa-py-check.yaml'), 'utf8');
     assert.deepEqual(YAML.stringify(result), expected);
@@ -211,7 +211,7 @@ describe("Support TMPL Placeholder Parameters in PyTEAL program", () => {
       TMPL_AMOUNT: 1000n
     };
 
-    const result = await op.ensureCompiled(stateless, false, scTmplParam) as PyASCCache;
+    const result = await op.ensureCompiled(stateless, false, scTmplParam);
 
     const expected = fs.readFileSync('expected-stateless.teal', 'utf-8');
     assert.equal(result.tealCode, expected);
@@ -223,7 +223,7 @@ describe("Support TMPL Placeholder Parameters in PyTEAL program", () => {
       TMPL_AMOUNT: 100n
     };
 
-    const result = await op.ensureCompiled(stateful, false, scTmplParam) as PyASCCache;
+    const result = await op.ensureCompiled(stateful, false, scTmplParam);
 
     const expected = fs.readFileSync('expected-stateful.teal', 'utf-8');
     assert.equal(result.tealCode, expected);

--- a/packages/algob/test/stubs/algo-operator.ts
+++ b/packages/algob/test/stubs/algo-operator.ts
@@ -110,7 +110,8 @@ export class AlgoOperatorDryRunImpl implements AlgoOperator {
       compiled: "ASDF", // the compiled code
       compiledHash: "ASDF", // hash returned by the compiler
       srcHash: 123, // source code hash
-      base64ToBytes: new Uint8Array(1) // compiled base64 in bytes
+      base64ToBytes: new Uint8Array(1), // compiled base64 in bytes
+      tealCode: "TEAL", // teal code
     };
   }
 


### PR DESCRIPTION
Closes #x

## Proposed Changes

+ now the tealCode is stored in cache when `scTmplParams` are used to compile TEAL with hardcoded params.
+ The ` PyASCCache` has been merged to `ASCCache`
