### PR TITLE
Migrate unique-nft example to use defaultAccounts

### DIFF
--- a/examples/unique-nft-asa/package.json
+++ b/examples/unique-nft-asa/package.json
@@ -17,6 +17,7 @@
     "algob": "algob",
     "lint": "eslint --ext .js,.ts scripts",
     "lint:fix": "eslint --fix --ext .js,.ts scripts",
+    "test": "echo testing unique-nft; mocha",
     "build:docs": "echo ok",
     "build": "echo ok"
   },

--- a/examples/unique-nft-asa/test/test.js
+++ b/examples/unique-nft-asa/test/test.js
@@ -23,9 +23,8 @@ describe('Unique NFT ASA tests', function () {
   const clearProgramFileName = 'nft-app-clear.py';
 
   this.beforeEach(async function () {
-    creator = new AccountStore(minBalance);
-    bob = new AccountStore(minBalance);
-    runtime = new Runtime([master, creator, bob]);
+    runtime = new Runtime([master]);
+    [creator, bob] = runtime.defaultAccounts();
 
     creationFlags = {
       sender: creator.account,
@@ -101,8 +100,7 @@ describe('Unique NFT ASA tests', function () {
 
   // Update account state
   function syncAccounts () {
-    creator = runtime.getAccount(creator.address);
-    bob = runtime.getAccount(bob.address);
+    [creator, bob] = runtime.defaultAccounts();
     statelessLsigAcc = runtime.getAccount(statelessLsig.address());
   }
 


### PR DESCRIPTION
Closes #x

## Proposed Changes

+ Use of `runtime.defaultAccounts`
+ Added `test` to its `package.json` file

