### PR TITLE
Update waitForConfirmation in web

### DIFF
--- a/packages/web/src/lib/constants.ts
+++ b/packages/web/src/lib/constants.ts
@@ -1,5 +1,6 @@
 export const MIN_UINT64 = 0n;
 export const MAX_UINT64 = 0xffffffffffffffffn;
 export const reDigit = /^\d+$/;
+export const WAIT_ROUNDS = 10; // for transaction confirmation
 // wallect connect
 export const ALGORAND_SIGN_TRANSACTION_REQUEST = "algo_signTxn";

--- a/packages/web/src/lib/myalgowallet-mode.ts
+++ b/packages/web/src/lib/myalgowallet-mode.ts
@@ -134,7 +134,7 @@ export class MyAlgoWalletSession {
 	 * Execute single transaction or group of transactions (atomic transaction)
 	 * @param execParams transaction parameters or atomic transaction parameters
 	 */
-	async executeTransaction(
+	async executeTx(
 		execParams: ExecParams | ExecParams[]
 	): Promise<algosdk.modelsv2.PendingTransactionResponse> {
 		let signedTxn;
@@ -170,5 +170,11 @@ export class MyAlgoWalletSession {
 
 		console.log("confirmedTx: ", confirmedTx);
 		return confirmedTx;
+	}
+	/** @deprecated */
+	async executeTransaction(
+		execParams: ExecParams | ExecParams[]
+	): Promise<algosdk.modelsv2.PendingTransactionResponse> {
+		return this.executeTx(execParams);
 	}
 }

--- a/packages/web/src/lib/myalgowallet-mode.ts
+++ b/packages/web/src/lib/myalgowallet-mode.ts
@@ -128,9 +128,8 @@ export class MyAlgoWalletSession {
 		const pendingInfo = await algosdk.waitForConfirmation(this.algodClient, txId, WAIT_ROUNDS);
 		if (pendingInfo["pool-error"]) {
 			throw new Error(`Transaction Pool Error: ${pendingInfo["pool-error"] as string}`);
-		} else {
-			return pendingInfo as algosdk.modelsv2.PendingTransactionResponse;
 		}
+		return pendingInfo as algosdk.modelsv2.PendingTransactionResponse;
 	}
 
 	/**

--- a/packages/web/src/lib/myalgowallet-mode.ts
+++ b/packages/web/src/lib/myalgowallet-mode.ts
@@ -128,7 +128,9 @@ export class MyAlgoWalletSession {
 		const pendingInfo = await algosdk.waitForConfirmation(this.algodClient, txId, WAIT_ROUNDS);
 		if (pendingInfo["pool-error"]) {
 			throw new Error(`Transaction Pool Error: ${pendingInfo["pool-error"] as string}`);
-		} else return pendingInfo as algosdk.modelsv2.PendingTransactionResponse;
+		} else {
+			return pendingInfo as algosdk.modelsv2.PendingTransactionResponse;
+		}
 	}
 
 	/**

--- a/packages/web/src/lib/myalgowallet-mode.ts
+++ b/packages/web/src/lib/myalgowallet-mode.ts
@@ -12,6 +12,7 @@ import { mkTxParams } from "..";
 import { ExecParams, TransactionInGroup } from "../types";
 import { algoexplorerAlgod } from "./api";
 import { mkTransaction } from "./txn";
+import { WAIT_ROUNDS } from "./constants";
 
 const CONFIRMED_ROUND = "confirmed-round";
 const LAST_ROUND = "last-round";
@@ -124,7 +125,7 @@ export class MyAlgoWalletSession {
 	private async waitForConfirmation(
 		txId: string
 	): Promise<algosdk.modelsv2.PendingTransactionResponse> {
-		const pendingInfo = await algosdk.waitForConfirmation(this.algodClient, txId, 10);
+		const pendingInfo = await algosdk.waitForConfirmation(this.algodClient, txId, WAIT_ROUNDS);
 		if (pendingInfo["pool-error"]) {
 			throw new Error(`Transaction Pool Error: ${pendingInfo["pool-error"] as string}`);
 		} else return pendingInfo as algosdk.modelsv2.PendingTransactionResponse;

--- a/packages/web/src/lib/wallectconnect-mode.ts
+++ b/packages/web/src/lib/wallectconnect-mode.ts
@@ -199,9 +199,8 @@ export class WallectConnectSession {
 		const pendingInfo = await algosdk.waitForConfirmation(this.algodClient, txId, WAIT_ROUNDS);
 		if (pendingInfo["pool-error"]) {
 			throw new Error(`Transaction Pool Error: ${pendingInfo["pool-error"] as string}`);
-		} else {
-		   return pendingInfo as algosdk.modelsv2.PendingTransactionResponse;
 		}
+		return pendingInfo as algosdk.modelsv2.PendingTransactionResponse;
 	}
 
 	/**

--- a/packages/web/src/lib/wallectconnect-mode.ts
+++ b/packages/web/src/lib/wallectconnect-mode.ts
@@ -13,7 +13,7 @@ import {
 	TransactionInGroup,
 } from "../types";
 import { algoexplorerAlgod, mkTxParams } from "./api";
-import { ALGORAND_SIGN_TRANSACTION_REQUEST } from "./constants";
+import { ALGORAND_SIGN_TRANSACTION_REQUEST, WAIT_ROUNDS } from "./constants";
 import { mkTransaction } from "./txn";
 
 const CONFIRMED_ROUND = "confirmed-round";
@@ -196,7 +196,7 @@ export class WallectConnectSession {
 	private async waitForConfirmation(
 		txId: string
 	): Promise<algosdk.modelsv2.PendingTransactionResponse> {
-		const pendingInfo = await algosdk.waitForConfirmation(this.algodClient, txId, 10);
+		const pendingInfo = await algosdk.waitForConfirmation(this.algodClient, txId, WAIT_ROUNDS);
 		if (pendingInfo["pool-error"]) {
 			throw new Error(`Transaction Pool Error: ${pendingInfo["pool-error"] as string}`);
 		} else return pendingInfo as algosdk.modelsv2.PendingTransactionResponse;


### PR DESCRIPTION
- Updated `waitForConfirmation` function to use `algosdk.waitForConfirmation` in walletConnect and MyAlgo wallet (done in last PR) rather than a loop.
- In AlgoSigner, it already have a function of `algod` to get the status of transaction, thus not updating it there