### PR TITLE
Chore(infrastructure)/remove indexer docker

### DIFF
--- a/infrastructure/Makefile
+++ b/infrastructure/Makefile
@@ -130,21 +130,6 @@ remove-reach:
 	$(REACH_PATH)/reach docker-reset
 	rm -r $(REACH_PATH)
 
-## --- Indexer jobs (docker based)--- ##
-
-indexer-docker-up:
-# clone indexer git repo: https://github.com/algorand/indexer.git and pull
-	@[ -d $(INDEXER_PATH) ] || git clone $(INDEXER_REMOTE_REPO) $(INDEXER_PATH)
-	(cd $(INDEXER_PATH); git reset --hard; git pull;)
-	@cd $(INDEXER_PATH) && docker-compose up
-
-indexer-docker-down:
-# stop and remove indexer containers and images
-	@if ! [ -d $(INDEXER_PATH) ]; then	\
-		echo "Repo not found: $(INDEXER_PATH) does not exist."; exit 1; fi
-	@(cd $(INDEXER_PATH); docker-compose down -v --rmi all --remove-orphans;)
-	rm -rf $(INDEXER_PATH)
-
 ## --- Indexer jobs (local based)--- ##
 
 setup-postgresql:

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -151,7 +151,7 @@ By default the indexer runs on port `8980` and `postgresdb` on port `5432` (on l
 
 ### Installation with docker
 
-The Indexer automatic start when you run sandbox algorand.
+The Indexer starts automatically when you run sandbox algorand.
 
 ### Installation on local
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -151,14 +151,7 @@ By default the indexer runs on port `8980` and `postgresdb` on port `5432` (on l
 
 ### Installation with docker
 
-**Prerequisite:** Make sure to have [Docker Compose](https://docs.docker.com/compose/install/) installed (with non root privilages).
-
-Following make jobs are provided:
-
-1. `indexer-docker-up`: Clones the indexer repo to `~/.algorand-indexer` and runs `docker-compose up` on the [docker-compose.yml](https://github.com/algorand/indexer/blob/develop/docker-compose.yml) file. Starts two services: [`indexer`](https://github.com/algorand/indexer/blob/develop/docker-compose.yml#L4)(on port `8980`) & [`indexer-db`](https://github.com/algorand/indexer/blob/develop/docker-compose.yml#L17)(on port `5432`).
-2. `indexer-docker-down`: Stops and removes indexer related container and images.
-
-**NOTE:** Docker based setup runs indexer in a "[read-only](https://github.com/algorand/indexer/blob/develop/docker/run.sh#L10)" mode, without connecting to the private-net `algod` node. Read more about this mode [here](https://github.com/algorand/indexer#read-only).
+The Indexer automatic start when you run sandbox algorand.
 
 ### Installation on local
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -151,7 +151,7 @@ By default the indexer runs on port `8980` and `postgresdb` on port `5432` (on l
 
 ### Installation with docker
 
-The Indexer starts automatically when you run sandbox algorand.
+The Indexer starts automatically when you run Algorand Sandbox.
 
 ### Installation on local
 


### PR DESCRIPTION
## Proposed Changes
+ When we start algod via sandbox docker. Indexer will automatic start with algod. We don't need command `indexer-docker-up/down` anymore.
+ Remove those commands. 
+ Update readme.md 

