### PR TITLE
base64_decode opcode cost

### DIFF
--- a/packages/runtime/src/interpreter/interpreter.ts
+++ b/packages/runtime/src/interpreter/interpreter.ts
@@ -554,7 +554,7 @@ export class Interpreter {
 			if (costFromExecute === undefined) {
 				this.cost += this.lineToCost[instruction.line];
 			} else {
-				this.cost = costFromExecute;
+				this.cost += costFromExecute;
 			}
 			if (this.tealVersion < 4) {
 				txReceipt.gas = this.gas;
@@ -564,7 +564,8 @@ export class Interpreter {
 					assertMaxCost(this.cost, this.mode);
 					txReceipt.gas = this.cost;
 				} else {
-					this.runtime.ctx.pooledApplCost += this.lineToCost[instruction.line];
+					//TODO here we need some updating probably the if else statement from above
+					this.runtime.ctx.pooledApplCost += this.cost;
 					assertMaxCost(
 						this.runtime.ctx.pooledApplCost,
 						ExecutionMode.APPLICATION,

--- a/packages/runtime/src/interpreter/interpreter.ts
+++ b/packages/runtime/src/interpreter/interpreter.ts
@@ -536,9 +536,6 @@ export class Interpreter {
 
 		while (this.instructionIndex < this.instructions.length) {
 			const instruction = this.instructions[this.instructionIndex];
-			//TODO this should return cost
-			const costFromExecute = instruction.execute(this.stack);
-
 			if (
 				this.runtime.ctx.isInnerTx &&
 				this.runtime.ctx.tx.type === TransactionTypeEnum.APPLICATION_CALL &&
@@ -548,14 +545,13 @@ export class Interpreter {
 					tealVersion: this.tealVersion,
 				});
 			}
+			const costFromExecute = instruction.execute(this.stack);
+			const cost =
+				costFromExecute === undefined ? this.lineToCost[instruction.line] : costFromExecute;
+			this.cost += cost;
 
 			// for teal version >= 4, cost is calculated dynamically at the time of execution
 			// for teal version < 4, cost is handled statically during parsing
-			if (costFromExecute === undefined) {
-				this.cost += this.lineToCost[instruction.line];
-			} else {
-				this.cost += costFromExecute;
-			}
 			if (this.tealVersion < 4) {
 				txReceipt.gas = this.gas;
 			}
@@ -564,7 +560,7 @@ export class Interpreter {
 					assertMaxCost(this.cost, this.mode);
 					txReceipt.gas = this.cost;
 				} else {
-					this.runtime.ctx.pooledApplCost += this.lineToCost[instruction.line];
+					this.runtime.ctx.pooledApplCost += cost;
 					assertMaxCost(
 						this.runtime.ctx.pooledApplCost,
 						ExecutionMode.APPLICATION,

--- a/packages/runtime/src/interpreter/interpreter.ts
+++ b/packages/runtime/src/interpreter/interpreter.ts
@@ -564,8 +564,7 @@ export class Interpreter {
 					assertMaxCost(this.cost, this.mode);
 					txReceipt.gas = this.cost;
 				} else {
-					//TODO here we need some updating probably the if else statement from above
-					this.runtime.ctx.pooledApplCost += this.cost;
+					this.runtime.ctx.pooledApplCost += this.lineToCost[instruction.line];
 					assertMaxCost(
 						this.runtime.ctx.pooledApplCost,
 						ExecutionMode.APPLICATION,

--- a/packages/runtime/src/interpreter/interpreter.ts
+++ b/packages/runtime/src/interpreter/interpreter.ts
@@ -546,8 +546,7 @@ export class Interpreter {
 				});
 			}
 			const costFromExecute = instruction.execute(this.stack);
-			const cost =
-				costFromExecute === undefined ? this.lineToCost[instruction.line] : costFromExecute;
+			const cost = costFromExecute === undefined ? 1 : costFromExecute;
 			this.cost += cost;
 
 			// for teal version >= 4, cost is calculated dynamically at the time of execution

--- a/packages/runtime/src/interpreter/opcode-list.ts
+++ b/packages/runtime/src/interpreter/opcode-list.ts
@@ -4794,9 +4794,10 @@ export class Base64Decode extends Op {
 		}
 	}
 
-	execute(stack: TEALStack): void {
+	execute(stack: TEALStack): number {
 		this.assertMinStackLen(stack, 1, this.line);
 		const last = this.assertBytes(stack.pop(), this.line);
+		const cost = 1 + Math.ceil(last.length / 16);
 		const enc = new TextDecoder("utf-8");
 		const decoded = enc.decode(last);
 		switch (this.encoding) {
@@ -4808,5 +4809,6 @@ export class Base64Decode extends Op {
 				break;
 		}
 		stack.push(new Uint8Array(Buffer.from(decoded.toString(), this.encoding)));
+		return cost;
 	}
 }

--- a/packages/runtime/src/interpreter/opcode-list.ts
+++ b/packages/runtime/src/interpreter/opcode-list.ts
@@ -4797,7 +4797,7 @@ export class Base64Decode extends Op {
 	execute(stack: TEALStack): number {
 		this.assertMinStackLen(stack, 1, this.line);
 		const last = this.assertBytes(stack.pop(), this.line);
-		const cost = 1 + Math.ceil(last.length / 16);
+		const cost = 1 + Math.ceil(last.length / 16); // cost = 1 + ceil(bytes / 16)
 		const enc = new TextDecoder("utf-8");
 		const decoded = enc.decode(last);
 		switch (this.encoding) {

--- a/packages/runtime/src/lib/constants.ts
+++ b/packages/runtime/src/lib/constants.ts
@@ -463,8 +463,6 @@ OpGasCost[6] = {
 };
 OpGasCost[7] = {
 	...OpGasCost[6],
-	//TODO: calculate the cost for the base64_decode opcode
-	// https://github.com/algorand/go-algorand/blob/master/data/transactions/logic/TEAL_opcodes.md#base64_decode-e
 };
 
 export const enum MathOp {

--- a/packages/runtime/src/parser/parser.ts
+++ b/packages/runtime/src/parser/parser.ts
@@ -45,8 +45,8 @@ import {
 	Bytecblock,
 	ByteDiv,
 	ByteEqualTo,
+	ByteGreaterThan,
 	ByteGreaterThanEqualTo,
-	ByteGreatorThan,
 	ByteLessThan,
 	ByteLessThanEqualTo,
 	ByteMod,
@@ -314,7 +314,7 @@ opCodeMap[4] = {
 	"b/": ByteDiv,
 	"b%": ByteMod,
 	"b<": ByteLessThan,
-	"b>": ByteGreatorThan,
+	"b>": ByteGreaterThan,
 	"b<=": ByteLessThanEqualTo,
 	"b>=": ByteGreaterThanEqualTo,
 	"b==": ByteEqualTo,
@@ -457,6 +457,9 @@ const interpreterReqList = new Set([
 	"gitxna",
 	"gitxnas",
 	"itxnas",
+	"sha256",
+	"sha512_256",
+	"keccak256",
 ]);
 
 const signatureModeOps = new Set(["arg", "args", "arg_0", "arg_1", "arg_2", "arg_3"]);

--- a/packages/runtime/test/src/interpreter/opcode-list.ts
+++ b/packages/runtime/test/src/interpreter/opcode-list.ts
@@ -57,8 +57,8 @@ import {
 	Bytecblock,
 	ByteDiv,
 	ByteEqualTo,
+	ByteGreaterThan,
 	ByteGreaterThanEqualTo,
-	ByteGreatorThan,
 	ByteLessThan,
 	ByteLessThanEqualTo,
 	ByteMod,
@@ -872,10 +872,11 @@ describe("Teal Opcodes", function () {
 
 	describe("Sha256", function () {
 		const stack = new Stack<StackElem>();
+		const interpreter = new Interpreter();
 
 		it("should return correct hash for Sha256", () => {
 			stack.push(parsing.stringToBytes("MESSAGE"));
-			const op = new Sha256([], 1);
+			const op = new Sha256([], 1, interpreter);
 			op.execute(stack);
 
 			const expected = Buffer.from(
@@ -889,21 +890,32 @@ describe("Teal Opcodes", function () {
 
 		it(
 			"should throw invalid type error sha256",
-			execExpectError(stack, [1n], new Sha256([], 1), RUNTIME_ERRORS.TEAL.INVALID_TYPE)
+			execExpectError(
+				stack,
+				[1n],
+				new Sha256([], 1, interpreter),
+				RUNTIME_ERRORS.TEAL.INVALID_TYPE
+			)
 		);
 
 		it(
 			"should throw error with Sha256 if stack is below min length",
-			execExpectError(stack, [], new Sha256([], 1), RUNTIME_ERRORS.TEAL.ASSERT_STACK_LENGTH)
+			execExpectError(
+				stack,
+				[],
+				new Sha256([], 1, interpreter),
+				RUNTIME_ERRORS.TEAL.ASSERT_STACK_LENGTH
+			)
 		);
 	});
 
 	describe("Sha512_256", function () {
 		const stack = new Stack<StackElem>();
+		const interpreter = new Interpreter();
 
 		it("should return correct hash for Sha512_256", function () {
 			stack.push(parsing.stringToBytes("MESSAGE"));
-			const op = new Sha512_256([], 1);
+			const op = new Sha512_256([], 1, interpreter);
 			op.execute(stack);
 
 			const expected = Buffer.from(
@@ -917,21 +929,32 @@ describe("Teal Opcodes", function () {
 
 		it(
 			"should throw invalid type error sha512_256",
-			execExpectError(stack, [1n], new Sha512_256([], 1), RUNTIME_ERRORS.TEAL.INVALID_TYPE)
+			execExpectError(
+				stack,
+				[1n],
+				new Sha512_256([], 1, interpreter),
+				RUNTIME_ERRORS.TEAL.INVALID_TYPE
+			)
 		);
 
 		it(
 			"should throw error with Sha512_256 if stack is below min length",
-			execExpectError(stack, [], new Sha512_256([], 1), RUNTIME_ERRORS.TEAL.ASSERT_STACK_LENGTH)
+			execExpectError(
+				stack,
+				[],
+				new Sha512_256([], 1, interpreter),
+				RUNTIME_ERRORS.TEAL.ASSERT_STACK_LENGTH
+			)
 		);
 	});
 
 	describe("keccak256", function () {
 		const stack = new Stack<StackElem>();
+		const interpreter = new Interpreter();
 
 		it("should return correct hash for keccak256", function () {
 			stack.push(parsing.stringToBytes("ALGORAND"));
-			const op = new Keccak256([], 1);
+			const op = new Keccak256([], 1, interpreter);
 			op.execute(stack);
 
 			// http://emn178.github.io/online-tools/keccak_256.html
@@ -946,12 +969,22 @@ describe("Teal Opcodes", function () {
 
 		it(
 			"should throw invalid type error Keccak256",
-			execExpectError(stack, [1n], new Keccak256([], 1), RUNTIME_ERRORS.TEAL.INVALID_TYPE)
+			execExpectError(
+				stack,
+				[1n],
+				new Keccak256([], 1, interpreter),
+				RUNTIME_ERRORS.TEAL.INVALID_TYPE
+			)
 		);
 
 		it(
 			"should throw error with keccak256 if stack is below min length",
-			execExpectError(stack, [], new Keccak256([], 1), RUNTIME_ERRORS.TEAL.ASSERT_STACK_LENGTH)
+			execExpectError(
+				stack,
+				[],
+				new Keccak256([], 1, interpreter),
+				RUNTIME_ERRORS.TEAL.ASSERT_STACK_LENGTH
+			)
 		);
 	});
 
@@ -5159,28 +5192,28 @@ describe("Teal Opcodes", function () {
 			});
 		});
 
-		describe("ByteGreatorThan", () => {
+		describe("ByteGreaterThan", () => {
 			const stack = new Stack<StackElem>();
 
-			it("should push 0/1 depending on value of two byte arrays for ByteGreatorThan", function () {
+			it("should push 0/1 depending on value of two byte arrays for ByteGreaterThan", function () {
 				// A is not greator B
 				stack.push(parsing.stringToBytes("A"));
 				stack.push(parsing.stringToBytes("B"));
-				let op = new ByteGreatorThan([], 0);
+				let op = new ByteGreaterThan([], 0);
 				op.execute(stack);
 				assert.deepEqual(stack.pop(), 0n);
 
 				// B > A
 				stack.push(parsing.stringToBytes("B"));
 				stack.push(parsing.stringToBytes("A"));
-				op = new ByteGreatorThan([], 0);
+				op = new ByteGreaterThan([], 0);
 				op.execute(stack);
 				assert.deepEqual(stack.pop(), 1n);
 
 				// A is not greator than A
 				stack.push(parsing.stringToBytes("A"));
 				stack.push(parsing.stringToBytes("A"));
-				op = new ByteGreatorThan([], 0);
+				op = new ByteGreaterThan([], 0);
 				op.execute(stack);
 				assert.deepEqual(stack.pop(), 0n);
 			});

--- a/packages/runtime/test/src/interpreter/opcode-list.ts
+++ b/packages/runtime/test/src/interpreter/opcode-list.ts
@@ -6667,6 +6667,41 @@ describe("Teal Opcodes", function () {
 			);
 		});
 
+		it("Should calculate the correct cost", () => {
+			let toPush = Buffer.from("", "utf-8");
+			stack.push(toPush);
+			let op = new Base64Decode(["URLEncoding"], 0);
+			let cost = op.execute(stack);
+			assert.deepEqual(1, cost); // base64_decode cost = 1
+
+			toPush = Buffer.from(
+				"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_",
+				"utf-8"
+			);
+			stack.push(toPush);
+			op = new Base64Decode(["URLEncoding"], 0);
+			cost = op.execute(stack);
+			assert.deepEqual(5, cost); // base64_decode cost = 5 (64 bytes -> 1 + 64/16)
+
+			toPush = Buffer.from(
+				"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234567",
+				"utf-8"
+			);
+			stack.push(toPush);
+			op = new Base64Decode(["URLEncoding"], 0);
+			cost = op.execute(stack);
+			assert.deepEqual(5, cost); // base64_decode cost = 5 (60 bytes -> 1 + ceil(60/16))
+
+			toPush = Buffer.from(
+				"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_AA==",
+				"utf-8"
+			);
+			stack.push(toPush);
+			op = new Base64Decode(["URLEncoding"], 0);
+			cost = op.execute(stack);
+			assert.deepEqual(6, cost); // base64_decode cost = 6 (68 bytes -> 1 + ceil(68/16))
+		});
+
 		it("Should throw an error when argument not provided", () => {
 			stack.push(toPushStd);
 			expectRuntimeError(() => new Base64Decode([], 0), RUNTIME_ERRORS.TEAL.ASSERT_LENGTH);

--- a/packages/runtime/test/src/parser/parser.ts
+++ b/packages/runtime/test/src/parser/parser.ts
@@ -2448,9 +2448,9 @@ describe("Parser", function () {
 		it("Should return correct opcode list for 'Crypto opcodes'", async () => {
 			const res = parser(getProgram(cryptoFile), ExecutionMode.SIGNATURE, interpreter);
 			const expected = [
-				new Sha256([], 1),
-				new Keccak256([], 2),
-				new Sha512_256([], 3),
+				new Sha256([], 1, interpreter),
+				new Keccak256([], 2, interpreter),
+				new Sha512_256([], 3, interpreter),
 				new Ed25519verify([], 4),
 			];
 			assert.deepEqual(res, expected);


### PR DESCRIPTION
Closes #x

## Proposed Changes

+ Update the `execute` method to return the cost 
+ Add unit tests for the method
+ Update the rest of the opcodes to return their cost from `execute` method (Only the opcodes that cost is different from 1 return their cost

## Potential followups
+ Add testing for the interpreter to check if the the cost is correct
