### PR TITLE
Add inner tx to execute return types

### DIFF
--- a/packages/algob/src/lib/tx.ts
+++ b/packages/algob/src/lib/tx.ts
@@ -310,7 +310,7 @@ export async function executeTx(
 		if (deployer.isDeployMode) {
 			await registerCheckpoints(deployer, execParams, txns, txIdxMap);
 		} else {
-			console.warn("deploy app/asset will not store in checkpoint on run mode");
+			console.warn("deploy app/asset will not be stored in checkpoint in run mode");
 		}
 		return confirmedTx;
 	} catch (error) {

--- a/packages/algob/src/lib/tx.ts
+++ b/packages/algob/src/lib/tx.ts
@@ -310,7 +310,7 @@ export async function executeTx(
 		if (deployer.isDeployMode) {
 			await registerCheckpoints(deployer, execParams, txns, txIdxMap);
 		} else {
-			console.warn("deploy app/asset not allowed in run mode");
+			console.warn("deploy app/asset will not store in checkpoint on run mode");
 		}
 		return confirmedTx;
 	} catch (error) {

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -780,6 +780,8 @@ export interface ConfirmedTxInfo {
 	"confirmed-round": number;
 	"asset-index": number;
 	"application-index": number;
-	"global-state-delta": string;
-	"local-state-delta": string;
+	"global-state-delta": algosdk.EncodedGlobalStateSchema;
+	"local-state-delta": algosdk.EncodedLocalStateSchema;
+	"inner-txns": ConfirmedTxInfo;
+	txn: algosdk.EncodedSignedTransaction;
 }

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -780,8 +780,8 @@ export interface ConfirmedTxInfo {
 	"confirmed-round": number;
 	"asset-index": number;
 	"application-index": number;
-	"global-state-delta": algosdk.EncodedGlobalStateSchema;
-	"local-state-delta": algosdk.EncodedLocalStateSchema;
-	"inner-txns": ConfirmedTxInfo;
+	"global-state-delta"?: algosdk.modelsv2.EvalDeltaKeyValue;
+	"local-state-delta"?: algosdk.modelsv2.AccountStateDelta;
+	"inner-txns"?: ConfirmedTxInfo;
 	txn: algosdk.EncodedSignedTransaction;
 }

--- a/packages/algob/test/lib/tx.ts
+++ b/packages/algob/test/lib/tx.ts
@@ -23,6 +23,7 @@ import {
 	mockLsig,
 	mockPendingTransactionInformation,
 	mockSuggestedParam,
+	TXN_OBJ,
 } from "../mocks/tx";
 import { AlgoOperatorDryRunImpl } from "../stubs/algo-operator";
 
@@ -93,8 +94,9 @@ describe("Opt-In to ASA", () => {
 				"confirmed-round": 1,
 				"asset-index": 1,
 				"application-index": 1,
-				"global-state-delta": "string",
-				"local-state-delta": "string",
+				txn: {
+					txn: TXN_OBJ,
+				},
 			},
 		];
 	});

--- a/packages/algob/test/mocks/tx.ts
+++ b/packages/algob/test/mocks/tx.ts
@@ -42,7 +42,8 @@ export const mockSuggestedParam: SuggestedParams = {
 const account = algosdk.generateAccount();
 const addr = algosdk.decodeAddress(account.addr);
 
-export const TXN_OBJ = {
+//MOCK Algorand Encoded Transaction
+export const TXN_OBJ: algosdk.EncodedTransaction = {
 	snd: Buffer.from(addr.publicKey),
 	rcv: Buffer.from(addr.publicKey),
 	arcv: Buffer.from(addr.publicKey),
@@ -97,12 +98,12 @@ export const TXN_OBJ = {
 		nui: 3,
 		nbs: 4,
 	},
-	txID: "transaction-id",
 	rekey: Buffer.from(addr.publicKey),
 	grp: Buffer.from("group"),
 	apep: 1,
 	nonpart: true,
 };
+
 export const mockConfirmedTx: ConfirmedTxInfo = {
 	"confirmed-round": 1,
 	"asset-index": 1,

--- a/packages/algob/test/mocks/tx.ts
+++ b/packages/algob/test/mocks/tx.ts
@@ -1,4 +1,4 @@
-import {
+import algosdk, {
 	Algodv2,
 	getApplicationAddress,
 	LogicSigAccount,
@@ -39,12 +39,77 @@ export const mockSuggestedParam: SuggestedParams = {
 	genesisHash: "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
 };
 
+const account = algosdk.generateAccount();
+const addr = algosdk.decodeAddress(account.addr);
+
+export const TXN_OBJ = {
+	snd: Buffer.from(addr.publicKey),
+	rcv: Buffer.from(addr.publicKey),
+	arcv: Buffer.from(addr.publicKey),
+	fee: 1000,
+	amt: 20200,
+	aamt: 100,
+	fv: 258820,
+	lv: 259820,
+	note: Buffer.from("Note"),
+	gen: "default-v1",
+	gh: Buffer.from("default-v1"),
+	lx: Buffer.from(""),
+	aclose: Buffer.from(addr.publicKey),
+	close: Buffer.from(addr.publicKey),
+	votekey: Buffer.from("voteKey"),
+	selkey: Buffer.from("selectionKey"),
+	votefst: 123,
+	votelst: 345,
+	votekd: 1234,
+	xaid: 1101,
+	caid: 101,
+	apar: {
+		t: 10,
+		dc: 0,
+		df: false,
+		m: Buffer.from(addr.publicKey),
+		r: Buffer.from(addr.publicKey),
+		f: Buffer.from(addr.publicKey),
+		c: Buffer.from(addr.publicKey),
+		un: "tst",
+		an: "testcoin",
+		au: "testURL",
+		am: Buffer.from("test-hash"),
+	},
+	fadd: Buffer.from(addr.publicKey),
+	faid: 202,
+	afrz: false,
+	apid: 1828,
+	apan: 0,
+	apap: Buffer.from("approval"),
+	apsu: Buffer.from("clear"),
+	apaa: [Buffer.from("arg1"), Buffer.from("arg2")],
+	apat: [],
+	apfa: [1828, 1002, 1003],
+	apas: [2001, 2002, 2003],
+	type: "pay",
+	apls: {
+		nui: 1,
+		nbs: 2,
+	},
+	apgs: {
+		nui: 3,
+		nbs: 4,
+	},
+	txID: "transaction-id",
+	rekey: Buffer.from(addr.publicKey),
+	grp: Buffer.from("group"),
+	apep: 1,
+	nonpart: true,
+};
 export const mockConfirmedTx: ConfirmedTxInfo = {
 	"confirmed-round": 1,
 	"asset-index": 1,
 	"application-index": 1,
-	"global-state-delta": "string",
-	"local-state-delta": "string",
+	txn: {
+		txn: TXN_OBJ,
+	},
 };
 
 export const mockAssetInfo: modelsv2.Asset = {
@@ -146,8 +211,9 @@ export const mockPendingTransactionInformation = {
 	"confirmed-round": 1,
 	"asset-index": 1,
 	"application-index": 1,
-	"global-state-delta": "string",
-	"local-state-delta": "string",
+	txn: {
+		txn: TXN_OBJ,
+	},
 };
 
 export const mockLsig: LogicSigAccount = new LogicSigAccount(mockProgram, []);


### PR DESCRIPTION
## Proposed Changes
Add missing fields to ConfirmedTxInfo

```ts
export interface ConfirmedTxInfo {
	"confirmed-round": number;
	"asset-index": number;
	"application-index": number;
	"global-state-delta"?: algosdk.modelsv2.EvalDeltaKeyValue;
	"local-state-delta"?: algosdk.modelsv2.AccountStateDelta;
	"inner-txns"?: ConfirmedTxInfo;
	txn: algosdk.EncodedSignedTransaction;
}

```
## Potential followups
