### PR TITLE
Nullish coalescing operator bug fix

### DIFF
--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -10,4 +10,4 @@ export { WebMode } from "./lib/web-mode";
 export { WallectConnectSession } from "./lib/wallectconnect-mode";
 export { MyAlgoWalletSession } from "./lib/myalgowallet-mode";
 export { getSuggestedParams, mkTxParams } from "./lib/api";
-export { mainnetURL, testnetURL } from "./lib/constants";
+export { mainnetURL, testnetURL, betanetURL } from "./lib/constants";

--- a/packages/web/src/lib/web-mode.ts
+++ b/packages/web/src/lib/web-mode.ts
@@ -186,7 +186,7 @@ export class WebMode {
 		for (const [txnId, txn] of txns.entries()) {
 			const singer: Sign = execParams[txnId];
 			if (singer.sign === SignType.LogicSignature) {
-				singer.lsig.lsig.args = singer.args ?? [];
+				singer.lsig.lsig.args = singer.args ? singer.args : [];
 				const lsigTxn = algosdk.signLogicSigTransaction(txn, singer.lsig);
 				signedTxn[txnId] = {
 					blob: this.algoSigner.encoding.msgpackToBase64(lsigTxn.blob),


### PR DESCRIPTION
- Fixed nullish coalescing operator which creates babel parsing error when run in templates

![image](https://user-images.githubusercontent.com/100185149/172926508-7807e15d-8709-4206-931f-58a77a8748e8.png)

- Export betanetURL directly from `index.tx`