### PR TITLE
create function to save checkpoint from confirmed txn(inner txn/normal txn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ Features, Bug Fixes, API Breaking, Deprecated, Infrastructure, Template Updates
 - Add Runtime.getAppByName(appName): get app by name declared in appDefinition.
 - For Algob.balanceOf(deployer, accountAddr, assetID) if assetID is undefined then function will return ALGO account balance.
 - Add new example [Trampoline](https://github.com/algorand-devrel/demo-avm1.1/tree/master/demos/trampoline)
-
+- Add `checkpointASA(asaName, txConfirmed)` and `checkpointApp(appName, txConfirmed)`. The methods will extract information about application and asa from `txConfirmed` and save it to checkpoint with name custom by developers.
+ 
 ### Bug Fixes
 
 - Fix number transaction in one call should be 256(include inner and atomic transaction).

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -575,7 +575,7 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 	}
 
 	/**
-	 * Save new ASA information(get from txConfirmation) to checkpoint
+	 * Save new ASA information(loaded from txConfirmation) to checkpoint
 	 * @param asaName name of asa
 	 * @param txConfirmation txn confirmation
 	 */

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -579,7 +579,7 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 	 * @param asaName name of asa
 	 * @param txConfirmation txn confirmation
 	 */
-	checkpointASA(asaName: string, txConfirmation: ConfirmedTxInfo): void {
+	addCheckpointASA(asaName: string, txConfirmation: ConfirmedTxInfo): void {
 		const txn = txConfirmation.txn.txn;
 
 		this.cpData.registerASA(this.networkName, asaName, {
@@ -600,7 +600,7 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 	 * @param appName app name
 	 * @param txConfirmation txn confirmation
 	 */
-	checkpointApp(appName: string, txConfirmation: ConfirmedTxInfo): void {
+	addCheckpointApp(appName: string, txConfirmation: ConfirmedTxInfo): void {
 		const { txn } = txConfirmation.txn;
 		this.cpData.registerSSC(this.networkName, appName, {
 			appID: txConfirmation["application-index"],
@@ -984,6 +984,28 @@ export class DeployerRunMode extends DeployerBasicMode implements Deployer {
 	registerSSCInfo(name: string, sscInfo: rtypes.AppInfo): void {
 		throw new BuilderError(ERRORS.BUILTIN_TASKS.DEPLOYER_EDIT_OUTSIDE_DEPLOY, {
 			methodName: "registerSSCInfo",
+		});
+	}
+
+	/**
+	 * Checkpoint feature disable on run mode
+	 * @param asaName name of asa
+	 * @param txConfirmation txn confirmation
+	 */
+	addCheckpointASA(asaName: string, txConfirmation: ConfirmedTxInfo): void {
+		throw new BuilderError(ERRORS.BUILTIN_TASKS.DEPLOYER_EDIT_OUTSIDE_DEPLOY, {
+			methodName: "addCheckpointASA",
+		});
+	}
+
+	/**
+	 * Checkpoint feature disable on run mode
+	 * @param appName app name
+	 * @param txConfirmation txn confirmation
+	 */
+	addCheckpointApp(appName: string, txConfirmation: ConfirmedTxInfo): void {
+		throw new BuilderError(ERRORS.BUILTIN_TASKS.DEPLOYER_EDIT_OUTSIDE_DEPLOY, {
+			methodName: "addCheckpointApp",
 		});
 	}
 

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -574,6 +574,11 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 		persistCheckpoint(this.txWriter.scriptName, this.cpData.strippedCP);
 	}
 
+	/**
+	 * Save new ASA information(get from txConfirmation) to checkpoint
+	 * @param asaName name of asa
+	 * @param txConfirmation txn confirmation
+	 */
 	registerASAInfoFromInnerTxn(asaName: string, txConfirmation: ConfirmedTxInfo): void {
 		const txn = txConfirmation.txn.txn;
 
@@ -590,8 +595,13 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 		});
 	}
 
+	/**
+	 * Save new application information(get from txConfirmation) to checkpoint
+	 * @param appName app name
+	 * @param txConfirmation txn confirmation
+	 */
 	registerAppInfoFromInnerTxn(appName: string, txConfirmation: ConfirmedTxInfo): void {
-		const txn = txConfirmation.txn.txn;
+		const { txn } = txConfirmation.txn;
 		this.cpData.registerSSC(this.networkName, appName, {
 			appID: txConfirmation["application-index"],
 			applicationAccount: algosdk.getApplicationAddress(txConfirmation["application-index"]),

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -577,15 +577,15 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 	/**
 	 * Save new ASA information(loaded from txConfirmation) to checkpoint
 	 * @param asaName name of asa
-	 * @param txConfirmation txn confirmation
+	 * @param confirmedTxObj txn confirmation
 	 */
-	addCheckpointASA(asaName: string, txConfirmation: ConfirmedTxInfo): void {
-		const txn = txConfirmation.txn.txn;
+	addCheckpointASA(asaName: string, confirmedTxObj: ConfirmedTxInfo): void {
+		const txn = confirmedTxObj.txn.txn;
 
 		this.cpData.registerASA(this.networkName, asaName, {
-			assetIndex: txConfirmation["asset-index"],
+			assetIndex: confirmedTxObj["asset-index"],
 			creator: algosdk.encodeAddress(txn.apar?.m as Uint8Array),
-			confirmedRound: txConfirmation["confirmed-round"],
+			confirmedRound: confirmedTxObj["confirmed-round"],
 			deleted: false,
 			assetDef: {
 				total: txn.apar?.t as number,
@@ -598,14 +598,14 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 	/**
 	 * Save new application information(get from txConfirmation) to checkpoint
 	 * @param appName app name
-	 * @param txConfirmation txn confirmation
+	 * @param confirmedTxObj txn confirmation
 	 */
-	addCheckpointApp(appName: string, txConfirmation: ConfirmedTxInfo): void {
-		const { txn } = txConfirmation.txn;
+	addCheckpointApp(appName: string, confirmedTxObj: ConfirmedTxInfo): void {
+		const { txn } = confirmedTxObj.txn;
 		this.cpData.registerSSC(this.networkName, appName, {
-			appID: txConfirmation["application-index"],
-			applicationAccount: algosdk.getApplicationAddress(txConfirmation["application-index"]),
-			confirmedRound: txConfirmation["confirmed-round"],
+			appID: confirmedTxObj["application-index"],
+			applicationAccount: algosdk.getApplicationAddress(confirmedTxObj["application-index"]),
+			confirmedRound: confirmedTxObj["confirmed-round"],
 			approvalFile: txn.apap?.toString("base64") as string,
 			clearFile: txn.apsu?.toString("base64") as string,
 			creator: algosdk.encodeAddress(txn.snd),

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -579,7 +579,7 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 	 * @param asaName name of asa
 	 * @param txConfirmation txn confirmation
 	 */
-	registerASAInfoFromInnerTxn(asaName: string, txConfirmation: ConfirmedTxInfo): void {
+	registerASAInfoFromConfirmTx(asaName: string, txConfirmation: ConfirmedTxInfo): void {
 		const txn = txConfirmation.txn.txn;
 
 		this.cpData.registerASA(this.networkName, asaName, {
@@ -600,7 +600,7 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 	 * @param appName app name
 	 * @param txConfirmation txn confirmation
 	 */
-	registerAppInfoFromInnerTxn(appName: string, txConfirmation: ConfirmedTxInfo): void {
+	registerAppInfoFromConfirmTx(appName: string, txConfirmation: ConfirmedTxInfo): void {
 		const { txn } = txConfirmation.txn;
 		this.cpData.registerSSC(this.networkName, appName, {
 			appID: txConfirmation["application-index"],

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -579,7 +579,7 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 	 * @param asaName name of asa
 	 * @param txConfirmation txn confirmation
 	 */
-	registerASAInfoFromConfirmTx(asaName: string, txConfirmation: ConfirmedTxInfo): void {
+	checkpointASA(asaName: string, txConfirmation: ConfirmedTxInfo): void {
 		const txn = txConfirmation.txn.txn;
 
 		this.cpData.registerASA(this.networkName, asaName, {
@@ -600,7 +600,7 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 	 * @param appName app name
 	 * @param txConfirmation txn confirmation
 	 */
-	registerAppInfoFromConfirmTx(appName: string, txConfirmation: ConfirmedTxInfo): void {
+	checkpointApp(appName: string, txConfirmation: ConfirmedTxInfo): void {
 		const { txn } = txConfirmation.txn;
 		this.cpData.registerSSC(this.networkName, appName, {
 			appID: txConfirmation["application-index"],

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -481,9 +481,9 @@ export interface Deployer {
 
 	registerSSCInfo: (name: string, sscInfo: rtypes.AppInfo) => void;
 
-	addCheckpointASA: (asaName: string, txConfirmation: ConfirmedTxInfo) => void;
+	addCheckpointASA: (asaName: string, confirmedTxObj: ConfirmedTxInfo) => void;
 
-	addCheckpointApp: (appName: string, txConfirmation: ConfirmedTxInfo) => void;
+	addCheckpointApp: (appName: string, confirmedTxObj: ConfirmedTxInfo) => void;
 
 	logTx: (message: string, txConfirmation: ConfirmedTxInfo) => void;
 

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -481,6 +481,10 @@ export interface Deployer {
 
 	registerSSCInfo: (name: string, sscInfo: rtypes.AppInfo) => void;
 
+	addCheckpointASA: (asaName: string, txConfirmation: ConfirmedTxInfo) => void;
+
+	addCheckpointApp: (appName: string, txConfirmation: ConfirmedTxInfo) => void;
+
 	logTx: (message: string, txConfirmation: ConfirmedTxInfo) => void;
 
 	/**

--- a/packages/algob/test/internal/deployer.ts
+++ b/packages/algob/test/internal/deployer.ts
@@ -677,8 +677,8 @@ describe("DeployerDeployMode", () => {
 		assert.deepEqual(res.assetDef, asaDef);
 	});
 
-	describe("registerAppInfoFromConfirmTx and registerAppInfoFromConfirmTx", function () {
-		it("registerAppInfoFromConfirmTX", () => {
+	describe("checkpointApp and checkpointASA", function () {
+		it("checkpointApp", () => {
 			const deployer = new DeployerDeployMode(deployerCfg);
 
 			const appInfo = {
@@ -693,7 +693,7 @@ describe("DeployerDeployMode", () => {
 				clearFile: "Y2xlYXI=",
 			};
 
-			deployer.registerAppInfoFromConfirmTx("app", mockConfirmedTx);
+			deployer.checkpointApp("app", mockConfirmedTx);
 
 			// get checkpoint data
 			const checkpointData = deployerCfg.cpData.precedingCP["network 123"].app
@@ -707,7 +707,7 @@ describe("DeployerDeployMode", () => {
 			assert.deepEqual(appInfo, deployer.getApp("app"));
 		});
 
-		it("registerASAInfoFromConfirmTx", () => {
+		it("checkpointASA", () => {
 			const deployer = new DeployerDeployMode(deployerCfg);
 
 			const asaInfo: rtypes.ASAInfo = {
@@ -719,7 +719,7 @@ describe("DeployerDeployMode", () => {
 				txID: algosdk.Transaction.from_obj_for_encoding(mockConfirmedTx.txn.txn).txID(),
 			};
 
-			deployer.registerASAInfoFromConfirmTx("asaName", mockConfirmedTx);
+			deployer.checkpointASA("asaName", mockConfirmedTx);
 
 			// get checkpoint data
 			const checkpointData = deployerCfg.cpData.precedingCP["network 123"].asa.get("asaName");

--- a/packages/algob/test/internal/deployer.ts
+++ b/packages/algob/test/internal/deployer.ts
@@ -733,7 +733,7 @@ describe("DeployerDeployMode", () => {
 			assert.deepEqual(asaInfo, deployer.getASAInfo("asaName"));
 		});
 
-		it("should fails when use addCheckpointApp and addCheckpointASA in run mode", () => {
+		it("should fail when we use addCheckpointApp and addCheckpointASA in run mode", () => {
 			const deployerRunMode = new DeployerRunMode(deployerCfg);
 
 			assert.throw(() => {

--- a/packages/algob/test/mocks/deployer.ts
+++ b/packages/algob/test/mocks/deployer.ts
@@ -78,6 +78,14 @@ export class FakeDeployer implements Deployer {
 		throw new Error("Not implemented");
 	}
 
+	addCheckpointASA(asaName: string, txConfirmation: ConfirmedTxInfo): void {
+		throw new Error("Not implemented");
+	}
+
+	addCheckpointApp(appName: string, txConfirmation: ConfirmedTxInfo): void {
+		throw new Error("Not implemented");
+	}
+
 	setScriptName(name: string): void {
 		this.scriptName = name;
 	}


### PR DESCRIPTION
## Proposed Changes

- create `checkpointApp` and `checkpointASA`. Those function take confirmTx and save (appInfo and AsaInfo) to checkpoint. Developers will use this function to inner transaction asset if they want. 

## Notes: 
- I don't check type of transaction now. 
- Only create new checkpoint, not update for now.

## Potential followups
