### PR TITLE
Find transaction in transaction group by id

### DIFF
--- a/packages/runtime/src/lib/txn.ts
+++ b/packages/runtime/src/lib/txn.ts
@@ -132,7 +132,8 @@ export function txnSpecByField(
 			return parsing.stringToBytes(tx.txID);
 		}
 		case "GroupIndex": {
-			result = gtxns.indexOf(tx);
+      const gtxnIDs = gtxns.map((gtx) => gtx.txID);
+      result = gtxnIDs.indexOf(tx.txID);
 			break;
 		}
 		case "NumAppArgs": {


### PR DESCRIPTION
Without this change `txn GroupIndex` can inappropriately return `-1` despite all fields of `tx` being the same as all fields of `gtxns[x]`. Apparently, the reason is that either `tx` or `gtxns` can be overwritten at some point by the same content but stored in a different memory location (`indexOf` uses `===` which compares objects *by reference*).

I had this problem when providing liquidity twice in a row in [Pact smart contract](https://github.com/pactfi/algorand-testbed/blob/master/constant_product.teal)

This change looks pretty safe, but I don't know if the root cause (change of memory locations) should be found and eliminated in addition or instead of this commit.
