### PR TITLE
ExecuteTx Return type update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ from `algosdk` and sends it to the network.
 - Fix `TxParams.noteb64` encoding - should use base64 decoder rather than TextEncoder.
 - Fix `ed25519verify` opcode implementation. Previously the signature was only checked against the data not the concatenation of "ProgData"||program||data. Additionally test scenarios was added to check the correct implementation. 
 
+### Breaking Changes
+
+#### @algo-builder/algob
+
+- `executeTx` promise now returns `TxReceipt[]` instead of `TxnReceipt[]`.
+- `getReceiptTxns` promise now returns `TxReceipt[]` instead of `TxnReceipt[]`.
+
+#### @algo-builder/web
+
+- `executeTx` promise now returns `TxReceipt` instead of `algosdk.modelsv2.PendingTransactionResponse`.
+
 ### Examples
 
 #### DAO

--- a/packages/algob/src/internal/constants.ts
+++ b/packages/algob/src/internal/constants.ts
@@ -1,2 +1,6 @@
 export const ALGOB_NAME = "algob";
 export const ALGOB_CHAIN_NAME = "algobchain";
+
+export const toCamelCase = (str: string) => {
+    return str.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+}

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -31,7 +31,7 @@ import type {
 	LsigInfo,
 	RuntimeEnv,
 	SCParams,
-	TxnReceipt,
+	TxReceipt,
 } from "../types";
 import { DeployerConfig } from "./deployer_cfg";
 
@@ -486,7 +486,7 @@ class DeployerBasicMode {
 	 * @param txns list transaction in group
 	 * @returns confirmed tx info of group
 	 */
-	async getReceiptTxns(txns: Transaction[]): Promise<TxnReceipt[]> {
+	async getReceiptTxns(txns: Transaction[]): Promise<TxReceipt[]> {
 		return await this.algoOp.getReceiptTxns(txns);
 	}
 }
@@ -876,7 +876,7 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 	 */
 	async executeTx(
 		transactions: wtypes.ExecParams[] | wtypes.TransactionAndSign[]
-	): Promise<TxnReceipt[]> {
+	): Promise<TxReceipt[]> {
 		return await executeTx(this, transactions);
 	}
 }
@@ -1063,7 +1063,7 @@ export class DeployerRunMode extends DeployerBasicMode implements Deployer {
 	 */
 	async executeTx(
 		transactions: wtypes.ExecParams[] | wtypes.TransactionAndSign[]
-	): Promise<TxnReceipt[]> {
+	): Promise<TxReceipt[]> {
 		return await executeTx(this, transactions);
 	}
 }

--- a/packages/algob/src/lib/tx.ts
+++ b/packages/algob/src/lib/tx.ts
@@ -9,7 +9,7 @@ import {
 } from "@algo-builder/web";
 import algosdk, { decodeSignedTransaction, SuggestedParams, Transaction } from "algosdk";
 
-import { ConfirmedTxInfo, Deployer, TxnReceipt } from "../types";
+import { ConfirmedTxInfo, Deployer, TxReceipt } from "../types";
 import { loadEncodedTxFromFile } from "./files";
 import { registerCheckpoints } from "./script-checkpoints";
 
@@ -282,7 +282,7 @@ export function signTransactions(txnAndSign: wtypes.TransactionAndSign[]): Uint8
 export async function executeTx(
 	deployer: Deployer,
 	transactions: wtypes.ExecParams[] | wtypes.TransactionAndSign[]
-): Promise<TxnReceipt[]> {
+): Promise<TxReceipt[]> {
 	let isSDK = false;
 	let signedTxn;
 	if (transactions.length === 0) {

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -1,6 +1,6 @@
 import { types as rtypes } from "@algo-builder/runtime";
 import { types as wtypes } from "@algo-builder/web";
-import algosdk, { LogicSigAccount, modelsv2, Transaction } from "algosdk";
+import algosdk, { EncodedTransaction, LogicSigAccount, modelsv2, Transaction, Account as AccountSDK } from "algosdk";
 
 import * as types from "./internal/core/params/argument-types";
 // Begin config types
@@ -391,6 +391,57 @@ export interface AssetScriptMap {
 	[assetName: string]: string;
 }
 
+export interface EncTx extends EncodedTransaction {
+	txID: string;
+	metaType?: wtypes.MetaType;
+	approvalProgram?: string;
+	clearProgram?: string;
+}
+
+export interface BaseTxReceipt {
+	txn: EncTx;
+	txID: string;
+	gas?: number;
+	logs?: Uint8Array[];
+}
+
+export type TxReceipt = BaseTxReceipt | AppInfo | ASAInfo;
+
+export interface DeployedAssetInfo {
+	creator: AccountAddress;
+	txID: string;
+	confirmedRound: number;
+	deleted: boolean;
+}
+
+// ASA deployment information (log)
+export interface ASAInfo extends DeployedAssetInfo {
+	assetIndex: number;
+	assetDef: wtypes.ASADef;
+	logs?: Uint8Array[];
+}
+
+// Stateful smart contract deployment information (log)
+export interface AppInfo extends DeployedAssetInfo {
+	appID: number;
+	applicationAccount: string;
+	timestamp: number;
+	approvalFile: string;
+	clearFile: string;
+	logs?: Uint8Array[];
+	gas?: number; // used in runtime
+}
+
+export interface AppDeploymentFlags extends wtypes.AppOptionalFlags {
+	sender: AccountSDK;
+	localInts: number;
+	localBytes: number;
+	globalInts: number;
+	globalBytes: number;
+	extraPages?: number;
+}
+
+
 export interface CheckpointFunctions {
 	/**
 	 * Queries a stateful smart contract info from checkpoint using key. */
@@ -499,7 +550,7 @@ export interface Deployer {
 	 * @param txns list transaction in group
 	 * @returns confirmed tx info of group
 	 */
-	getReceiptTxns: (txns: Transaction[]) => Promise<TxnReceipt[]>;
+	getReceiptTxns: (txns: Transaction[]) => Promise<TxReceipt[]>;
 
 	/**
 	 * Funds logic signature account (Contract Account).
@@ -724,7 +775,7 @@ export interface Deployer {
 	 */
 	executeTx: (
 		transactions: wtypes.ExecParams[] | wtypes.TransactionAndSign[]
-	) => Promise<TxnReceipt[]>;
+	) => Promise<TxReceipt[]>;
 }
 
 // ************************

--- a/packages/web/src/lib/parsing.ts
+++ b/packages/web/src/lib/parsing.ts
@@ -95,3 +95,15 @@ export function parseAppArgs(appArgs?: Array<Uint8Array | string>): Uint8Array[]
 	}
 	return args as Uint8Array[];
 }
+
+export function toCamelCase(str: string) {
+	return str.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+}
+
+export function convertKeysToCamelCase(object: any) {
+	let newObject: any = {}
+	Object.keys(object).forEach((key) => {
+		newObject[toCamelCase(key)] = object[key]
+	})
+	return newObject
+}

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-unused-vars */
 
 import { IClientMeta } from "@walletconnect/types";
-import { Account as AccountSDK, LogicSigAccount, Transaction } from "algosdk";
+import { Account as AccountSDK, EncodedTransaction, LogicSigAccount, Transaction } from "algosdk";
 import * as z from "zod";
+import { types } from ".";
 
 import { WalletMultisigMetadata, WalletTransaction } from "./algo-signer-types";
 import { WAIT_ROUNDS } from "./lib/constants";
@@ -441,6 +442,56 @@ export interface HttpNetworkConfig {
 	port: string | number;
 	token: string | AlgodTokenHeader | CustomTokenHeader;
 	httpHeaders?: { [name: string]: string };
+}
+
+export interface EncTx extends EncodedTransaction {
+	txID: string;
+	metaType?: types.MetaType;
+	approvalProgram?: string;
+	clearProgram?: string;
+}
+
+export interface BaseTxReceipt {
+	txn: EncTx;
+	txID: string;
+	gas?: number;
+	logs?: Uint8Array[];
+}
+
+export type TxReceipt = BaseTxReceipt | AppInfo | ASAInfo;
+
+export interface DeployedAssetInfo {
+	creator: AccountAddress;
+	txID: string;
+	confirmedRound: number;
+	deleted: boolean;
+}
+
+// ASA deployment information (log)
+export interface ASAInfo extends DeployedAssetInfo {
+	assetIndex: number;
+	assetDef: types.ASADef;
+	logs?: Uint8Array[];
+}
+
+// Stateful smart contract deployment information (log)
+export interface AppInfo extends DeployedAssetInfo {
+	appID: number;
+	applicationAccount: string;
+	timestamp: number;
+	approvalFile: string;
+	clearFile: string;
+	logs?: Uint8Array[];
+	gas?: number; // used in runtime
+}
+
+export interface AppDeploymentFlags extends AppOptionalFlags {
+	sender: AccountSDK;
+	localInts: number;
+	localBytes: number;
+	globalInts: number;
+	globalBytes: number;
+	extraPages?: number;
 }
 
 export { WAIT_ROUNDS };


### PR DESCRIPTION
Make executeTx return type compatible between Runtime, Algob and Web from `TxnReceipt ` to `TxReceipt `