### PR TITLE
Feature: Add support loadLogic for *.teal program and SCParam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Features, Bug Fixes, API Breaking, Deprecated, Infrastructure, Template Updates
 - Changed default sample project license to ISC
 - Fix `txn AssetSender` should return zero address by default.
 - Add unit tests for all transaction types in runtime executeTx.
+- Add support loadLogic for *.teal program and SCParam.
 
 #### Examples
 

--- a/packages/runtime/src/lib/load-program.ts
+++ b/packages/runtime/src/lib/load-program.ts
@@ -7,7 +7,8 @@ import { ASSETS_DIR, PyCompileOp, pyExt, tealExt } from "./pycompile-op";
 /**
  * returns program TEAL code.
  * @param fileName filename in /assets. Must end with .teal OR .py
- * @param scInitParam smart contract template parameters, used to set hardcoded values in .py or .teal smart contract.
+ * @param scInitParam smart contract template parameters, used to set hardcoded values
+ * in .py or .teal smart contract.
  * @param logs only show logs on console when set as true. By default this value is true
  */
 export function getProgram(fileName: string, scInitParam?: SCParams, logs = true): string {

--- a/packages/runtime/src/lib/load-program.ts
+++ b/packages/runtime/src/lib/load-program.ts
@@ -7,8 +7,7 @@ import { ASSETS_DIR, PyCompileOp, pyExt, tealExt } from "./pycompile-op";
 /**
  * returns program TEAL code.
  * @param fileName filename in /assets. Must end with .teal OR .py
- * @param scInitParam smart contract template parameters, used to set hardcoded values in .py smart contract.
- * (used only when compiling PyTEAL to TEAL)
+ * @param scInitParam smart contract template parameters, used to set hardcoded values in .py or .teal smart contract.
  * @param logs only show logs on console when set as true. By default this value is true
  */
 export function getProgram(fileName: string, scInitParam?: SCParams, logs = true): string {
@@ -19,9 +18,12 @@ export function getProgram(fileName: string, scInitParam?: SCParams, logs = true
 		throw new Error(`filename "${fileName}" must end with "${tealExt}" or "${pyExt}"`);
 	}
 
+	const pyOp = new PyCompileOp();
 	if (fileName.endsWith(pyExt)) {
-		const pyOp = new PyCompileOp();
 		return pyOp.ensurePyTEALCompiled(fileName, scInitParam, logs);
+	} else {
+		// teal
+		const [replaceParams] = pyOp.parseScTmplParam(scInitParam, logs);
+		return pyOp.replaceTempValues(program, replaceParams);
 	}
-	return program;
 }

--- a/packages/runtime/test/fixtures/escrow-account/assets/crowdFundApproval.teal
+++ b/packages/runtime/test/fixtures/escrow-account/assets/crowdFundApproval.teal
@@ -1,0 +1,470 @@
+#pragma version 4
+// Fund Start Date unixtimestamp
+// Fund End Date unixtimestamp
+// Fund Goal
+// Fund Amount - total
+// Escrow Address
+// Creator Address
+
+// check if the app is being created
+// if so save creator
+int 0
+txn ApplicationID
+==
+
+// if not creation skip this section
+bz not_creation
+
+// save the creator address to the global state
+byte "Creator"
+txn Sender
+app_global_put
+
+// verify that 5 arguments are passed
+txn NumAppArgs
+int 5
+==
+bz failed
+
+//store the start date
+byte "StartDate"
+txna ApplicationArgs 0
+btoi
+app_global_put
+
+// store the end date
+byte "EndDate"
+txna ApplicationArgs 1
+btoi
+app_global_put
+
+// store fund goal
+byte "Goal"
+txna ApplicationArgs 2
+btoi
+app_global_put
+
+// store the fund receiver
+byte "Receiver"
+txna ApplicationArgs 3
+app_global_put
+
+// set the total raised to 0 and store it
+byte "Total"
+int 0
+app_global_put
+
+// store the fund close date
+byte "FundCloseDate"
+txna ApplicationArgs 4
+btoi
+app_global_put
+
+// return a success
+int 1
+return
+
+not_creation:
+// check if this is deletion transaction
+int DeleteApplication
+txn OnCompletion
+==
+bz not_deletion
+
+// NOTE: To delete the app
+// The creator must empty the escrow
+// to the fund receiver if the escrow has funds
+
+// only the creator
+// can delete the app
+byte "Creator"
+app_global_get
+txn Sender
+==
+
+// check that we are past fund close date
+global LatestTimestamp
+byte "FundCloseDate"
+app_global_get
+>=
+&&
+bz failed
+
+// if escrow balance is zero
+// let the app be deleted
+// escrow account must be passed
+// into the call as an argument
+int 0
+int 1
+balance
+==
+
+// if the balance is 0 allow the delete
+bnz finished
+
+// if the escrow is not empty then
+// there must be need two transactions
+// in a group
+global GroupSize
+int 2
+==
+
+// second tx is an payment
+gtxn 1 TypeEnum
+int pay
+==
+&&
+
+// the second payment transaction should be
+// a close out transaction to receiver
+byte "Receiver"
+app_global_get
+gtxn 1 CloseRemainderTo
+==
+&&
+
+// the amount of the payment transaction
+// should be 0
+gtxn 1 Amount
+int 0
+==
+&&
+
+// the sender of the payment transaction
+// should be the escrow account
+byte "Escrow"
+app_global_get
+gtxn 1 Sender
+==
+&&
+bz failed
+int 1
+return
+
+not_deletion:
+// check if this is update
+int UpdateApplication
+txn OnCompletion
+==
+
+bz not_update
+// verify that the creator is
+// making the call
+byte "Creator"
+app_global_get
+txn Sender
+==
+
+// the call should pass the escrow
+// address
+txn NumAppArgs
+int 1
+==
+&&
+bz failed
+
+// store the address in global state
+// this parameter should be addr:
+byte "Escrow"
+txna ApplicationArgs 0
+app_global_put
+int 1
+return
+
+not_update:
+// check for closeout
+int CloseOut
+txn OnCompletion
+==
+bnz close_out
+
+// check if no params are
+// passed in, which should
+// only happen when someone just
+// wants to optin
+// note that the code is written
+// to allow opting in and donating with
+// one call
+int 0
+txn NumAppArgs
+==
+bz check_params
+
+// Verify someone is
+// not just opting in
+int OptIn
+txn OnCompletion
+==
+bz failed
+int 1
+return
+
+check_params:
+// donate
+txna ApplicationArgs 0
+byte "donate"
+==
+bnz donate
+
+// reclaim
+txna ApplicationArgs 0
+byte "reclaim"
+==
+bnz reclaim
+
+// claim
+txna ApplicationArgs 0
+byte "claim"
+==
+bnz claim
+b failed
+
+
+donate:
+
+
+// check dates to verify
+// in valid range
+global LatestTimestamp
+byte "StartDate"
+app_global_get
+>=
+global LatestTimestamp
+byte "EndDate"
+app_global_get
+<=
+&&
+bz failed
+
+// check if grouped with
+// two transactions
+global GroupSize
+int 2
+==
+
+// verify second tx is payment
+gtxn 1 TypeEnum
+int 1
+==
+&&
+bz failed
+
+// verify escrow is receiving
+// second payment tx
+byte "Escrow"
+app_global_get
+gtxn 1 Receiver
+==
+bz failed
+
+// increment the total
+// funds raised so far
+byte "Total"
+app_global_get
+gtxn 1 Amount
++
+store 1
+byte "Total"
+load 1
+app_global_put
+
+// increment or set giving amount
+// for the account that is donating
+int 0 //sender
+txn ApplicationID
+byte "MyAmountGiven"
+app_local_get_ex
+
+// check if a new giver
+// or existing giver
+// and store the value
+// in the givers local storage
+bz new_giver
+gtxn 1 Amount
++
+store 3
+int 0 //sender
+byte "MyAmountGiven"
+load 3
+app_local_put
+b finished
+new_giver:
+int 0 //sender
+byte "MyAmountGiven"
+gtxn 1 Amount
+app_local_put
+b finished
+
+
+claim:
+// verify there are 2 transactions
+// in the group
+global GroupSize
+int 2
+==
+bz failed
+
+// verify that the receiver
+// of the payment transaction
+// is the address stored
+// when the fund was created
+gtxn 1 Receiver
+byte "Receiver"
+app_global_get
+==
+
+// verify the sender
+// of the payment transaction
+// is the escrow account
+gtxn 1 Sender
+byte "Escrow"
+app_global_get
+==
+&&
+
+// verify that the CloseRemainderTo
+// attribute is set to the receiver
+gtxn 1 CloseRemainderTo
+byte "Receiver"
+app_global_get
+==
+&&
+
+// verify that the fund end date
+// has passed
+global LatestTimestamp
+byte "EndDate"
+app_global_get
+>
+&&
+bz failed
+
+// verify that the goal was reached
+byte "Total"
+app_global_get
+byte "Goal"
+app_global_get
+>=
+bz failed
+b finished
+
+//don't check amount because
+//escrow account may receive
+//more than the goal
+//Could check for total vs tx1 amount
+
+//Fund did not meet total
+//Allow people to reclaim funds
+//may be an issue when the last
+//person reclaims because of min balance
+//without a closeto
+// only 1 reclaim tx is allowed per account
+
+
+reclaim:
+// verify there are 2 transactions
+// in the group
+global GroupSize
+int 2
+==
+bz failed
+
+// verify that smart contract
+// caller is the payment
+// transaction receiver
+gtxn 1 Receiver
+gtxn 0 Sender
+==
+
+// Verify that payment
+// transaction is from the escrow
+gtxn 1 Sender
+byte "Escrow"
+app_global_get
+==
+&&
+
+// verify that fund end date has passed
+global LatestTimestamp
+byte "EndDate"
+app_global_get
+>
+&&
+
+// verify the fund goal was
+// not met
+byte "Total"
+app_global_get
+byte "Goal"
+app_global_get
+<
+&&
+
+// because the escrow
+// has to pay the fee
+// the amount of the
+// payment transaction
+// plus the fee should
+// be less than or equal to
+// the amount originally
+// given
+gtxn 1 Amount
+gtxn 1 Fee
++
+int 0
+byte "MyAmountGiven"
+app_local_get
+<=
+&&
+bz failed
+
+//check the escrow account total
+//--app-account for the escrow
+// needs to pass the address
+// of the escrow
+// check that this is the
+// last recovered donation
+// if it is, then CloseRemainderTo
+// should be set
+gtxn 1 Fee
+gtxn 1 Amount
++
+
+// int 1 is ref to escrow
+int 1
+balance
+==
+gtxn 1 CloseRemainderTo
+global ZeroAddress
+==
+||
+bz failed
+
+// decrement the given amount
+// of the sender
+int 0
+byte "MyAmountGiven"
+app_local_get
+gtxn 1 Amount
+-
+gtxn 1 Fee
+-
+store 5
+int 0
+byte "MyAmountGiven"
+load 5
+app_local_put
+b finished
+
+//call if this is a closeout op
+close_out:
+int 1
+return
+
+failed:
+int 0
+return
+
+finished:
+int 1
+return

--- a/packages/runtime/test/fixtures/escrow-account/assets/crowdFundClear.teal
+++ b/packages/runtime/test/fixtures/escrow-account/assets/crowdFundClear.teal
@@ -1,0 +1,4 @@
+#pragma version 4
+// approve
+int 1
+return

--- a/packages/runtime/test/fixtures/escrow-account/assets/crowdFundEscrow.teal
+++ b/packages/runtime/test/fixtures/escrow-account/assets/crowdFundEscrow.teal
@@ -1,0 +1,29 @@
+#pragma version 5
+global GroupSize
+int 2
+==
+gtxn 0 TypeEnum
+int appl
+==
+&&
+gtxn 0 ApplicationID
+int 1
+==
+&&
+gtxn 0 OnCompletion
+int NoOp
+==
+gtxn 0 OnCompletion
+int DeleteApplication
+==
+||
+&&
+gtxn 0 RekeyTo
+global ZeroAddress
+==
+gtxn 1 RekeyTo
+global ZeroAddress
+==
+&&
+&&
+return

--- a/packages/runtime/test/src/logicsig.ts
+++ b/packages/runtime/test/src/logicsig.ts
@@ -12,7 +12,7 @@ const programName = "escrow.teal";
 const multiSigProg = "sample-asc.teal";
 const crowdFundEscrow = "crowdFundEscrow.teal";
 
-describe("Load logic for teal program", () => {
+describe("Logic Signature", () => {
 	useFixture("escrow-account");
 	let john: AccountStore;
 	let bob: AccountStore;

--- a/packages/runtime/test/src/logicsig.ts
+++ b/packages/runtime/test/src/logicsig.ts
@@ -100,7 +100,7 @@ describe("Logic Signature", () => {
 		assert.equal(result, false);
 	});
 
-	it("should handle contract lsig (crowd fund escrow account) verification correctly with non-empty smart contract parmas", () => {
+	it ("Should handle contract lsig (crowd fund escrow account) verification correctly with non-empty smart contract params", () => {
 		// create application
 		applicationId = runtime.deployApp(
 			bob.account,

--- a/packages/runtime/test/src/logicsig.ts
+++ b/packages/runtime/test/src/logicsig.ts
@@ -1,14 +1,16 @@
 import { decodeAddress, multisigAddress, MultisigMetadata } from "algosdk";
 import { assert } from "chai";
-
+const { convert } = require("@algo-builder/algob");
 import { AccountStore } from "../../src/account";
 import { RUNTIME_ERRORS } from "../../src/errors/errors-list";
 import { Runtime } from "../../src/runtime";
 import { useFixture } from "../helpers/integration";
 import { expectRuntimeError } from "../helpers/runtime-errors";
+const { types } = require("@algo-builder/web");
 
 const programName = "escrow.teal";
 const multiSigProg = "sample-asc.teal";
+const crowdFundEscrow = "crowdFundEscrow.teal";
 
 describe("Logic Signature", () => {
 	useFixture("escrow-account");
@@ -16,12 +18,49 @@ describe("Logic Signature", () => {
 	let bob: AccountStore;
 	let runtime: Runtime;
 	let johnPk: Uint8Array;
+	let goal: number;
+	let crowdfundApprovalFileName: string;
+	let crowdFundClearFileName: string;
+	let now: Date;
+	let beginDate: Date;
+	let endDate: Date;
+	let fundCloseDate: Date;
+	let creationArgs: Array<{}>;
+	let appDefinition: any;
+	let applicationId: any
 
 	before(() => {
+		goal = 0.01e6;
+		crowdfundApprovalFileName = "crowdFundApproval.teal";
+		crowdFundClearFileName = "crowdFundClear.teal";
 		john = new AccountStore(10);
-		bob = new AccountStore(100);
+		bob = new AccountStore(10e6);
 		runtime = new Runtime([john, bob]);
 		johnPk = decodeAddress(john.address).publicKey;
+		now = new Date();
+		beginDate = endDate = fundCloseDate = now
+		beginDate.setSeconds(now.getSeconds() + 2);
+		endDate.setSeconds(now.getSeconds() + 12000);
+		fundCloseDate.setSeconds(fundCloseDate.getSeconds() + 120000);
+
+		creationArgs = [
+			convert.uint64ToBigEndian(beginDate.getTime()),
+			convert.uint64ToBigEndian(endDate.getTime()),
+			`int:${goal}`, // args similar to `goal --app-arg ..` are also supported
+			convert.addressToPk(bob.address),
+			convert.uint64ToBigEndian(fundCloseDate.getTime()),
+		];
+
+		appDefinition = {
+			appName: "crowdfundingApp",
+			metaType: types.MetaType.FILE,
+			approvalProgramFilename: crowdfundApprovalFileName,
+			clearProgramFilename: crowdFundClearFileName,
+			localInts: 1,
+			localBytes: 0,
+			globalInts: 5,
+			globalBytes: 3,
+		};
 	});
 
 	it("john should be able to create a delegated signature", () => {
@@ -43,6 +82,35 @@ describe("Logic Signature", () => {
 	it("should handle contract lsig (escrow account) verification correctly", () => {
 		const lsig = runtime.loadLogic(programName);
 
+		let result = lsig.lsig.verify(decodeAddress(lsig.address()).publicKey);
+		assert.equal(result, true);
+
+		result = lsig.lsig.verify(johnPk);
+		assert.equal(result, false);
+	});
+
+	it("should handle contract lsig (escrow account) verification correctly with empty smart contract parmas", () => {
+		// empty smart contract param with teal
+		const lsig = runtime.loadLogic(programName, {});
+
+		let result = lsig.lsig.verify(decodeAddress(lsig.address()).publicKey);
+		assert.equal(result, true);
+
+		result = lsig.lsig.verify(johnPk);
+		assert.equal(result, false);
+	});
+
+	it("should handle contract lsig (crowd fund escrow account) verification correctly with non-empty smart contract parmas", () => {
+		// create application
+		applicationId = runtime.deployApp(
+			bob.account,
+			{ ...appDefinition, appArgs: creationArgs },
+			{}
+		).appID;
+
+		assert(applicationId);
+		// setup escrow account
+		const lsig = runtime.loadLogic(crowdFundEscrow, { APP_ID: applicationId });
 		let result = lsig.lsig.verify(decodeAddress(lsig.address()).publicKey);
 		assert.equal(result, true);
 


### PR DESCRIPTION
Currently, only teal in python can be compiled with smart contract params but was not possible to compile teal with smart contract params. I have now added support for this to compile teal file along with smart contract params.

This resolves: https://github.com/scale-it/algo-builder/issues/662