### PR TITLE
fix `yarn algob:dev` command in algob package

### DIFF
--- a/packages/algob/README.md
+++ b/packages/algob/README.md
@@ -48,7 +48,7 @@ Also, it my be helpful to link the binary:
 
     yarn link
 
-You can run another alogb cli on dev project follow pattern `yarn algob:dev:cmd <sub command>`. e.g:
+You can run another alogb cli on dev project by following pattern `yarn algob:dev:cmd <sub command>`. e.g:
 
     yarn algob:dev:cmd test
     yarn algob:dev:cmd deploy

--- a/packages/algob/README.md
+++ b/packages/algob/README.md
@@ -47,3 +47,8 @@ In that directory you should update the `config.algob.js`. The `algob:dev` comma
 Also, it my be helpful to link the binary:
 
     yarn link
+
+You can run another alogb cli on dev project follow pattern `yarn algob:dev:cmd <sub command>`. e.g:
+
+    yarn algob:dev:cmd test
+    yarn algob:dev:cmd deploy

--- a/packages/algob/package.json
+++ b/packages/algob/package.json
@@ -34,7 +34,8 @@
 		"build:watch": "tsc -w -p .",
 		"clean": "rimraf builtin-tasks internal *.d.ts *.map *.js tsconfig.ts buildinfo build",
 		"prepublish": "yarn build; sh ./prepublish.sh",
-		"algob:dev": "sh ./setup_dev_project.sh"
+		"algob:dev": "sh ./project-dev-script.sh create",
+		"algob:dev:cmd": "sh ./project-dev-script.sh exec"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Proposed Changes

- Fix `yarn algob:dev` in algob package
- Add `yarn algob:dev:cmd` to run other algob sub commands on dev project.

## TODO

- [ ] update change log

## Potential followups
