### PR TITLE
Update `sendAndWait` and `waitForConfirmation` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,10 +73,11 @@ from `algosdk` and sends it to the network.
 
 #### @algo-builder/web
 
-- `executeTx`, `sendAndWait`, `waitForConfirmation` promise now returns [TxnReceipt](https://github.com/scale-it/algo-builder/blob/master/packages/web/src/types.ts#L458) instead of `algosdk.modelsv2.PendingTransactionResponse`.
+- `executeTx`, `sendAndWait`, `waitForConfirmation`, `sendTxAndWait` promise now returns [TxnReceipt](https://github.com/scale-it/algo-builder/blob/master/packages/web/src/types.ts#L458) instead of `algosdk.modelsv2.PendingTransactionResponse`.
 
 #### @algo-builder/algob
-- `sendAndWait`, `waitForConfirmation`, `executeSignedTxnFromFile` promise now returns `TxnReceipt` instead of `ConfirmedTxInfo`.
+- `sendAndWait`, `waitForConfirmation`, `executeSignedTxnFromFile`, `sendTxAndWait` promise now returns `TxnReceipt` instead of `ConfirmedTxInfo`.
+- `logTx` second argument of `txConfirmation` now expects type of `TxnReceipt` instead of `ConfirmedTxInfo`.
 
 ### Examples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,10 @@ from `algosdk` and sends it to the network.
 
 #### @algo-builder/web
 
-- `executeTx` promise now returns [TxnReceipt](https://github.com/scale-it/algo-builder/blob/master/packages/web/src/types.ts#L458) instead of `algosdk.modelsv2.PendingTransactionResponse`.
+- `executeTx`, `sendAndWait`, `waitForConfirmation` promise now returns [TxnReceipt](https://github.com/scale-it/algo-builder/blob/master/packages/web/src/types.ts#L458) instead of `algosdk.modelsv2.PendingTransactionResponse`.
+
+#### @algo-builder/algob
+- `sendAndWait`, `waitForConfirmation`, `executeSignedTxnFromFile` promise now returns `TxnReceipt` instead of `ConfirmedTxInfo`.
 
 ### Examples
 

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -127,7 +127,7 @@ class DeployerBasicMode {
 		return this.algoOp.algodClient;
 	}
 
-	async waitForConfirmation(txId: string): Promise<ConfirmedTxInfo> {
+	async waitForConfirmation(txId: string): Promise<TxnReceipt> {
 		return await this.algoOp.waitForConfirmation(txId);
 	}
 
@@ -274,7 +274,7 @@ class DeployerBasicMode {
 	sendAndWait(
 		rawTxns: Uint8Array | Uint8Array[],
 		waitRounds = wtypes.WAIT_ROUNDS
-	): Promise<ConfirmedTxInfo> {
+	): Promise<TxnReceipt> {
 		return this.algoOp.sendAndWait(rawTxns, waitRounds);
 	}
 

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -32,7 +32,6 @@ import type {
 	ASCCache,
 	CheckpointFunctions,
 	CheckpointRepo,
-	ConfirmedTxInfo,
 	Deployer,
 	FundASCFlags,
 	LogicSig,
@@ -270,6 +269,7 @@ class DeployerBasicMode {
 	 * Send signed transaction to network and wait for confirmation
 	 * @param rawTxns Signed Transaction(s)
 	 * @param waitRounds number of rounds to wait for transaction to be confirmed - default is 10
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
 	 */
 	sendAndWait(
 		rawTxns: Uint8Array | Uint8Array[],
@@ -560,9 +560,9 @@ class DeployerBasicMode {
 	 * Sends signedTransaction and waits for the response
 	 * @param transactions array of signedTransaction objects.
 	 * @param rounds number of rounds to wait for response
-	 * @returns ConfirmedTxInfo
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
 	 */
-	sendTxAndWait(transactions: SignedTransaction[], rounds?: number): Promise<ConfirmedTxInfo> {
+	sendTxAndWait(transactions: SignedTransaction[], rounds?: number): Promise<TxnReceipt> {
 		if (transactions.length < 1) {
 			throw Error("No transactions to process");
 		} else {
@@ -656,7 +656,7 @@ export class DeployerDeployMode extends DeployerBasicMode implements Deployer {
 	/**
 	 * Log transaction with message using txwriter
 	 */
-	logTx(message: string, txConfirmation: ConfirmedTxInfo): void {
+	logTx(message: string, txConfirmation: TxnReceipt): void {
 		this.txWriter.push(message, txConfirmation);
 	}
 
@@ -1013,7 +1013,7 @@ export class DeployerRunMode extends DeployerBasicMode implements Deployer {
 		});
 	}
 
-	logTx(message: string, txConfirmation: ConfirmedTxInfo): void {
+	logTx(message: string, txConfirmation: TxnReceipt): void {
 		throw new BuilderError(ERRORS.BUILTIN_TASKS.DEPLOYER_EDIT_OUTSIDE_DEPLOY, {
 			methodName: "logTx",
 		});

--- a/packages/algob/src/lib/algo-operator.ts
+++ b/packages/algob/src/lib/algo-operator.ts
@@ -157,8 +157,7 @@ export class AlgoOperatorImpl implements AlgoOperator {
 			throw new Error(`Transaction Pool Error: ${pendingInfo["pool-error"] as string}`);
 		}
 		if (pendingInfo[confirmedRound] !== null && pendingInfo[confirmedRound] > 0) {
-			const data: TxnReceipt = { txID: txId, ...pendingInfo as ConfirmedTxInfo }
-			return data
+			return { txID: txId, ...pendingInfo as ConfirmedTxInfo } as TxnReceipt
 		}
 		throw new Error("timeout");
 	}

--- a/packages/algob/src/lib/algo-operator.ts
+++ b/packages/algob/src/lib/algo-operator.ts
@@ -136,6 +136,7 @@ export class AlgoOperatorImpl implements AlgoOperator {
 	 * Send signed transaction to network and wait for confirmation
 	 * @param rawTxns Signed Transaction(s)
 	 * @param waitRounds number of rounds to wait for transaction to be confirmed - default is 10
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
 	 */
 	async sendAndWait(
 		rawTxns: Uint8Array | Uint8Array[],
@@ -145,9 +146,13 @@ export class AlgoOperatorImpl implements AlgoOperator {
 		return await this.waitForConfirmation(txInfo.txId, waitRounds);
 	}
 
-	// Source:
-	// https://github.com/algorand/docs/blob/master/examples/assets/v2/javascript/AssetExample.js#L21
-	// Function used to wait for a tx confirmation
+	/**
+	 * Source: https://github.com/algorand/docs/blob/master/examples/assets/v2/javascript/AssetExample.js#L21
+	 * Function used to wait for a tx confirmation
+	 * @param txId txn ID for which confirmation is required 
+	 * @param waitRounds number of rounds to wait for transaction to be confirmed - default is 10
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
+	 */
 	async waitForConfirmation(
 		txId: string,
 		waitRounds = wtypes.WAIT_ROUNDS

--- a/packages/algob/src/lib/algo-operator.ts
+++ b/packages/algob/src/lib/algo-operator.ts
@@ -73,7 +73,7 @@ export interface AlgoOperator {
 		txWriter: txWriter,
 		scTmplParams?: SCParams
 	) => Promise<rtypes.AppInfo>;
-	waitForConfirmation: (txId: string) => Promise<ConfirmedTxInfo>;
+	waitForConfirmation: (txId: string) => Promise<TxnReceipt>;
 	getAssetByID: (assetIndex: number | bigint) => Promise<modelsv2.Asset>;
 	optInAccountToASA: (
 		asaName: string,
@@ -120,7 +120,7 @@ export interface AlgoOperator {
 	sendAndWait: (
 		rawTxns: Uint8Array | Uint8Array[],
 		waitRounds: number
-	) => Promise<ConfirmedTxInfo>;
+	) => Promise<TxnReceipt>;
 	getReceiptTxns: (txns: Transaction[]) => Promise<TxnReceipt[]>;
 }
 
@@ -140,7 +140,7 @@ export class AlgoOperatorImpl implements AlgoOperator {
 	async sendAndWait(
 		rawTxns: Uint8Array | Uint8Array[],
 		waitRounds = wtypes.WAIT_ROUNDS
-	): Promise<ConfirmedTxInfo> {
+	): Promise<TxnReceipt> {
 		const txInfo = await this.algodClient.sendRawTransaction(rawTxns).do();
 		return await this.waitForConfirmation(txInfo.txId, waitRounds);
 	}
@@ -151,13 +151,14 @@ export class AlgoOperatorImpl implements AlgoOperator {
 	async waitForConfirmation(
 		txId: string,
 		waitRounds = wtypes.WAIT_ROUNDS
-	): Promise<ConfirmedTxInfo> {
+	): Promise<TxnReceipt> {
 		const pendingInfo = await algosdk.waitForConfirmation(this.algodClient, txId, waitRounds);
 		if (pendingInfo["pool-error"]) {
 			throw new Error(`Transaction Pool Error: ${pendingInfo["pool-error"] as string}`);
 		}
 		if (pendingInfo[confirmedRound] !== null && pendingInfo[confirmedRound] > 0) {
-			return pendingInfo as ConfirmedTxInfo;
+			const data: TxnReceipt = { txID: txId, ...pendingInfo as ConfirmedTxInfo }
+			return data
 		}
 		throw new Error("timeout");
 	}

--- a/packages/algob/src/lib/tx.ts
+++ b/packages/algob/src/lib/tx.ts
@@ -9,7 +9,7 @@ import {
 } from "@algo-builder/web";
 import algosdk, { decodeSignedTransaction, SuggestedParams, Transaction } from "algosdk";
 
-import { ConfirmedTxInfo, Deployer, TxnReceipt } from "../types";
+import { Deployer, TxnReceipt } from "../types";
 import { loadEncodedTxFromFile } from "./files";
 import { registerCheckpoints } from "./script-checkpoints";
 

--- a/packages/algob/src/lib/tx.ts
+++ b/packages/algob/src/lib/tx.ts
@@ -331,6 +331,7 @@ export async function executeTx(
  * current network's blockchain block height.
  * @param deployer Deployer
  * @param fileName raw(encoded) signed txn file
+ * @returns TxnReceipt which includes confirmed txn response along with txID
  */
 export async function executeSignedTxnFromFile(
 	deployer: Deployer,

--- a/packages/algob/src/lib/tx.ts
+++ b/packages/algob/src/lib/tx.ts
@@ -335,7 +335,7 @@ export async function executeTx(
 export async function executeSignedTxnFromFile(
 	deployer: Deployer,
 	fileName: string
-): Promise<ConfirmedTxInfo> {
+): Promise<TxnReceipt> {
 	const signedTxn = loadEncodedTxFromFile(fileName);
 	if (signedTxn === undefined) {
 		throw new Error(`File ${fileName} does not exist`);

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -492,7 +492,7 @@ export interface Deployer {
 	 * Send signed transaction to network and wait for confirmation
 	 * @param rawTxns Signed Transaction(s)
 	 */
-	sendAndWait: (rawTxns: Uint8Array | Uint8Array[]) => Promise<ConfirmedTxInfo>;
+	sendAndWait: (rawTxns: Uint8Array | Uint8Array[]) => Promise<TxnReceipt>;
 
 	/**
 	 * Return receipts for each transaction in group txn
@@ -605,7 +605,7 @@ export interface Deployer {
 
 	/**
 	 * Queries blockchain for a given transaction and waits until it will be processed. */
-	waitForConfirmation: (txId: string) => Promise<ConfirmedTxInfo>;
+	waitForConfirmation: (txId: string) => Promise<TxnReceipt>;
 
 	/**
 	 * Queries blockchain using algodv2 for asset information by index  */

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -486,11 +486,12 @@ export interface Deployer {
 
 	registerSSCInfo: (name: string, sscInfo: rtypes.AppInfo) => void;
 
-	logTx: (message: string, txConfirmation: ConfirmedTxInfo) => void;
+	logTx: (message: string, txConfirmation: TxnReceipt) => void;
 
 	/**
 	 * Send signed transaction to network and wait for confirmation
 	 * @param rawTxns Signed Transaction(s)
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
 	 */
 	sendAndWait: (rawTxns: Uint8Array | Uint8Array[]) => Promise<TxnReceipt>;
 

--- a/packages/algob/test/lib/tx.ts
+++ b/packages/algob/test/lib/tx.ts
@@ -178,7 +178,7 @@ describe("ASA modify fields", function () {
 	 * Verifies correct asset fields are sent to network
 	 * @param rawTxns rawTxns Signed transactions in Uint8Array
 	 */
-	function checkTx(rawTxns: Uint8Array | Uint8Array[]): Promise<ConfirmedTxInfo> {
+	function checkTx(rawTxns: Uint8Array | Uint8Array[]): Promise<TxnReceipt> {
 		if (Array.isArray(rawTxns)) {
 			// verify here if group tx
 		} else {

--- a/packages/algob/test/lib/tx.ts
+++ b/packages/algob/test/lib/tx.ts
@@ -12,7 +12,7 @@ import { TextEncoder } from "util";
 
 import { DeployerDeployMode, DeployerRunMode } from "../../src/internal/deployer";
 import { DeployerConfig } from "../../src/internal/deployer_cfg";
-import { ConfirmedTxInfo, Deployer, TxnReceipt } from "../../src/types";
+import { Deployer, TxnReceipt } from "../../src/types";
 import { expectBuilderError, expectBuilderErrorAsync } from "../helpers/errors";
 import { mkEnv } from "../helpers/params";
 import { useFixtureProject, useFixtureProjectCopy } from "../helpers/project";

--- a/packages/algob/test/mocks/deployer.ts
+++ b/packages/algob/test/mocks/deployer.ts
@@ -4,7 +4,6 @@ import algosdk, { Account, LogicSigAccount, modelsv2 } from "algosdk";
 
 import type {
 	ASCCache,
-	ConfirmedTxInfo,
 	Deployer,
 	FundASCFlags,
 	LogicSig,
@@ -63,7 +62,7 @@ export class FakeDeployer implements Deployer {
 		throw new Error("Not implemented");
 	}
 
-	logTx(message: string, txConfirmation: ConfirmedTxInfo): void {
+	logTx(message: string, txConfirmation: TxnReceipt): void {
 		throw new Error("Not implemented");
 	}
 

--- a/packages/algob/test/mocks/deployer.ts
+++ b/packages/algob/test/mocks/deployer.ts
@@ -67,7 +67,7 @@ export class FakeDeployer implements Deployer {
 		throw new Error("Not implemented");
 	}
 
-	sendAndWait(rawTxns: Uint8Array | Uint8Array[]): Promise<ConfirmedTxInfo> {
+	sendAndWait(rawTxns: Uint8Array | Uint8Array[]): Promise<TxnReceipt> {
 		throw new Error("Not implemented");
 	}
 
@@ -119,7 +119,7 @@ export class FakeDeployer implements Deployer {
 		throw new Error("Not implemented");
 	}
 
-	addCheckpointKV(key: string, value: string): void {} // eslint-disable-line @typescript-eslint/no-empty-function
+	addCheckpointKV(key: string, value: string): void { } // eslint-disable-line @typescript-eslint/no-empty-function
 
 	getCheckpointKV(key: string): string | undefined {
 		return "metadata";
@@ -237,7 +237,7 @@ export class FakeDeployer implements Deployer {
 		throw new Error("Not implemented");
 	}
 
-	waitForConfirmation(txId: string): Promise<ConfirmedTxInfo> {
+	waitForConfirmation(txId: string): Promise<TxnReceipt> {
 		throw new Error("Not implemented");
 	}
 

--- a/packages/algob/test/mocks/tx.ts
+++ b/packages/algob/test/mocks/tx.ts
@@ -112,7 +112,7 @@ export const mockTxnReceipt: TxnReceipt = {
 	txn: {
 		txn: TXN_OBJ,
 	},
-}
+};
 
 export const mockAssetInfo: modelsv2.Asset = {
 	index: 1,

--- a/packages/algob/test/mocks/tx.ts
+++ b/packages/algob/test/mocks/tx.ts
@@ -6,7 +6,7 @@ import algosdk, {
 	SuggestedParams,
 } from "algosdk";
 
-import { ConfirmedTxInfo } from "../../src/types";
+import { ConfirmedTxInfo, TxnReceipt } from "../../src/types";
 import { bobAcc } from "./account";
 
 export const mockAlgod = new Algodv2("dummyToken", "https://dummyNetwork", 8080);
@@ -112,6 +112,11 @@ export const mockConfirmedTx: ConfirmedTxInfo = {
 		txn: TXN_OBJ,
 	},
 };
+
+export const mockTxnReceipt: TxnReceipt = {
+	txID: "1",
+	...mockConfirmedTx
+}
 
 export const mockAssetInfo: modelsv2.Asset = {
 	index: 1,

--- a/packages/algob/test/mocks/tx.ts
+++ b/packages/algob/test/mocks/tx.ts
@@ -6,7 +6,7 @@ import algosdk, {
 	SuggestedParams,
 } from "algosdk";
 
-import { ConfirmedTxInfo, TxnReceipt } from "../../src/types";
+import { TxnReceipt } from "../../src/types";
 import { bobAcc } from "./account";
 
 export const mockAlgod = new Algodv2("dummyToken", "https://dummyNetwork", 8080);
@@ -104,18 +104,14 @@ export const TXN_OBJ: algosdk.EncodedTransaction = {
 	nonpart: true,
 };
 
-export const mockConfirmedTx: ConfirmedTxInfo = {
+export const mockTxnReceipt: TxnReceipt = {
+	txID: "1",
 	"confirmed-round": 1,
 	"asset-index": 1,
 	"application-index": 1,
 	txn: {
 		txn: TXN_OBJ,
 	},
-};
-
-export const mockTxnReceipt: TxnReceipt = {
-	txID: "1",
-	...mockConfirmedTx
 }
 
 export const mockAssetInfo: modelsv2.Asset = {

--- a/packages/algob/test/stubs/algo-operator.ts
+++ b/packages/algob/test/stubs/algo-operator.ts
@@ -6,7 +6,6 @@ import { txWriter } from "../../src/internal/tx-log-writer";
 import { AlgoOperator } from "../../src/lib/algo-operator";
 import {
 	ASCCache,
-	ConfirmedTxInfo,
 	FundASCFlags,
 	LsigInfo,
 	SCParams,
@@ -16,8 +15,8 @@ import {
 	MOCK_APPLICATION_ADDRESS,
 	mockAlgod,
 	mockAssetInfo,
-	mockConfirmedTx,
 	mockPendingTransactionInformation,
+	mockTxnReceipt,
 } from "../mocks/tx";
 
 export class AlgoOperatorDryRunImpl implements AlgoOperator {
@@ -31,13 +30,13 @@ export class AlgoOperatorDryRunImpl implements AlgoOperator {
 		});
 	}
 
-	sendAndWait(rawTxns: Uint8Array | Uint8Array[]): Promise<ConfirmedTxInfo> {
+	sendAndWait(rawTxns: Uint8Array | Uint8Array[]): Promise<TxnReceipt> {
 		return new Promise((resolve, _reject) => {
-			resolve(mockConfirmedTx);
+			resolve(mockTxnReceipt);
 		});
 	}
 
-	waitForConfirmation(_txID: string): Promise<ConfirmedTxInfo> {
+	waitForConfirmation(_txID: string): Promise<TxnReceipt> {
 		return this.sendAndWait([]);
 	}
 

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -1157,7 +1157,7 @@ export class Runtime {
 	/**
 	 * Sends signedTransaction and waits for the response
 	 * @param transactions array of signedTransaction objects.
-	 * @returns TxnReceipt
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
 	 */
 	sendTxAndWait(transactions: SignedTransaction[]): TxnReceipt[] {
 		return this.executeTx(transactions);

--- a/packages/web/src/lib/myalgowallet-mode.ts
+++ b/packages/web/src/lib/myalgowallet-mode.ts
@@ -153,7 +153,7 @@ export class MyAlgoWalletSession {
 	}
 
 	// Function used to wait for a tx confirmation
-	private async waitForConfirmation(
+	async waitForConfirmation(
 		txId: string,
 		waitRounds = WAIT_ROUNDS
 	): Promise<TxnReceipt> {

--- a/packages/web/src/lib/myalgowallet-mode.ts
+++ b/packages/web/src/lib/myalgowallet-mode.ts
@@ -143,6 +143,7 @@ export class MyAlgoWalletSession {
 	 * Send signed transaction to network and wait for confirmation
 	 * @param rawTxns Signed Transaction(s)
 	 * @param waitRounds number of rounds to wait for transaction to be confirmed - default is 10
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
 	 */
 	async sendAndWait(
 		rawTxns: Uint8Array | Uint8Array[],
@@ -262,7 +263,7 @@ export class MyAlgoWalletSession {
 	 * Sends signedTransaction and waits for the response
 	 * @param transactions array of signedTransaction objects.
 	 * @param rounds number of rounds to wait for response
-	 * @returns TxnReceipt
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
 	 */
 	async sendTxAndWait(transactions: SignedTransaction[], rounds?: number): Promise<TxnReceipt> {
 		if (transactions.length < 1) {

--- a/packages/web/src/lib/myalgowallet-mode.ts
+++ b/packages/web/src/lib/myalgowallet-mode.ts
@@ -153,7 +153,12 @@ export class MyAlgoWalletSession {
 		return await this.waitForConfirmation(txInfo.txId, waitRounds);
 	}
 
-	// Function used to wait for a tx confirmation
+	/**
+	* Function used to wait for a tx confirmation
+	* @param txId txn ID for which confirmation is required 
+	* @param waitRounds number of rounds to wait for transaction to be confirmed - default is 10
+	* @returns TxnReceipt which includes confirmed txn response along with txID
+	*/
 	async waitForConfirmation(
 		txId: string,
 		waitRounds = WAIT_ROUNDS

--- a/packages/web/src/lib/wallectconnect-mode.ts
+++ b/packages/web/src/lib/wallectconnect-mode.ts
@@ -197,7 +197,12 @@ export class WallectConnectSession {
 		return await this.waitForConfirmation(txInfo.txId, waitRounds);
 	}
 
-	// Function used to wait for a tx confirmation
+	/**
+	* Function used to wait for a tx confirmation
+	* @param txId txn ID for which confirmation is required 
+	* @param waitRounds number of rounds to wait for transaction to be confirmed - default is 10
+	* @returns TxnReceipt which includes confirmed txn response along with txID
+	*/
 	async waitForConfirmation(
 		txId: string,
 		waitRounds = WAIT_ROUNDS

--- a/packages/web/src/lib/wallectconnect-mode.ts
+++ b/packages/web/src/lib/wallectconnect-mode.ts
@@ -197,7 +197,7 @@ export class WallectConnectSession {
 	}
 
 	// Function used to wait for a tx confirmation
-	private async waitForConfirmation(
+	async waitForConfirmation(
 		txId: string,
 		waitRounds = WAIT_ROUNDS
 	): Promise<TxnReceipt> {

--- a/packages/web/src/lib/wallectconnect-mode.ts
+++ b/packages/web/src/lib/wallectconnect-mode.ts
@@ -187,6 +187,7 @@ export class WallectConnectSession {
 	 * Send signed transaction to network and wait for confirmation
 	 * @param rawTxns Signed Transaction(s)
 	 * @param waitRounds number of rounds to wait for transaction to be confirmed - default is 10
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
 	 */
 	async sendAndWait(
 		rawTxns: Uint8Array | Uint8Array[],
@@ -322,7 +323,7 @@ export class WallectConnectSession {
 	 * Sends signedTransaction and waits for the response
 	 * @param transactions array of signedTransaction objects.
 	 * @param rounds number of rounds to wait for response
-	 * @returns TxnReceipt
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
 	 */
 	async sendTxAndWait(transactions: SignedTransaction[], rounds?: number): Promise<TxnReceipt> {
 		if (transactions.length < 1) {

--- a/packages/web/src/lib/web-mode.ts
+++ b/packages/web/src/lib/web-mode.ts
@@ -38,6 +38,7 @@ export class WebMode {
 	 * wait for confirmation for transaction using transaction id
 	 * @param txId Transaction id
 	 * @param waitRounds number of rounds to wait for transaction to be confirmed - default is 10
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
 	 */
 	async waitForConfirmation(
 		txId: string,
@@ -77,6 +78,7 @@ export class WebMode {
 	 * Send signed transaction to network and wait for confirmation
 	 * @param signedTxn Signed Transaction blob encoded in base64
 	 * @param waitRounds number of rounds to wait for transaction to be confirmed - default is 10
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
 	 */
 	async sendAndWait(signedTxn: string, waitRounds: number = WAIT_ROUNDS): Promise<TxnReceipt> {
 		const txInfo = await this.algoSigner.send({
@@ -347,7 +349,7 @@ export class WebMode {
 	 * Sends signedTransaction and waits for the response
 	 * @param transactions array of signedTransaction objects.
 	 * @param rounds number of rounds to wait for response
-	 * @returns TxnReceipt
+	 * @returns TxnReceipt which includes confirmed txn response along with txID
 	 */
 	async sendTxAndWait(transactions: SignedTransaction[], rounds?: number): Promise<TxnReceipt> {
 		if (transactions.length < 1) {


### PR DESCRIPTION
Updated return type of `waitForConfirmation` and `sendAndWait` in `algob` and `web` packages to make it compatible with `executeTx`