### PR TITLE
Feature: Add --javascript flag to `algo init` task

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -191,7 +191,7 @@ algob -h deploy
 You can write your scripts and tests in JavaScript. If you don't add any flag to `init`, then default is javascript. Example, if you follow the [Create an algob project](#create-an-algob-project) section then:
 
 ```shell
-yarn run algob init <path-where-to-create>
+yarn run algob init <path-where-to-create> --javascript
 ```
 #### Example on `algob init` with javascript
 
@@ -199,7 +199,7 @@ You can use below command to initialize the javascript project in `sample-projec
 If `sample-project` folder is not present then it will create one for you. 
 
 ```shell
-yarn run algob init ./sample-project
+yarn run algob init ./sample-project --javascript
 ```
 
 ### Using algob with a TypeScript project
@@ -209,6 +209,7 @@ You can write your scripts and tests in TS. To initialize a new typescript proje
 ```shell
 yarn run algob init <path-where-to-create> --typescript
 ```
+
 #### Example on `algob init` with typescript
 
 You can use below command to initialize the typescript project in `sample-project` folder.

--- a/packages/algob/src/builtin-tasks/init.ts
+++ b/packages/algob/src/builtin-tasks/init.ts
@@ -5,6 +5,7 @@ import { TASK_INIT } from "./task-names";
 export default function (): void {
 	task(TASK_INIT, "Initializes a new project(JS by default) in the given directory")
 		.addPositionalParam<string>("newProjectLocation", "Location of the new project")
+		.addFlag("javascript", "Initializes a new javascript project in the given directory")
 		.addFlag("typescript", "Initializes a new typescript project in the given directory")
 		.addFlag("infrastructure", "Initializes a new project without infrastructure folder")
 		.addFlag("npm", "Use npm instead for yarn")

--- a/packages/runtime/src/interpreter/opcode-list.ts
+++ b/packages/runtime/src/interpreter/opcode-list.ts
@@ -764,7 +764,6 @@ export class Ed25519verify extends Op {
 		const addr = this.assertBytes(stack.pop(), this.line);
 		const signature = this.assertBytes(stack.pop(), this.line);
 		const data = this.assertBytes(stack.pop(), this.line);
-		const bytes = Buffer.from(this.program);
 
 		const toBeHashed = "ProgData".concat(this.program);
 		const programHash = Buffer.from(sha512_256(toBeHashed));

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -7,7 +7,6 @@ import algosdk, {
 	SignedTransaction,
 	Transaction,
 } from "algosdk";
-import { exec } from "child_process";
 import cloneDeep from "lodash.clonedeep";
 import nacl from "tweetnacl";
 

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -7,21 +7,6 @@ import algosdk, {
 	modelsv2,
 	Transaction,
 } from "algosdk";
-
-import {
-	Add,
-	Addr,
-	Arg,
-	Byte,
-	Bytec,
-	Bytecblock,
-	Div,
-	Int,
-	Len,
-	Mul,
-	Pragma,
-	Sub,
-} from "./interpreter/opcode-list";
 import { TxnFields } from "./lib/constants";
 import type { IStack } from "./lib/stack";
 

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -7,6 +7,7 @@ import algosdk, {
 	modelsv2,
 	Transaction,
 } from "algosdk";
+
 import { TxnFields } from "./lib/constants";
 import type { IStack } from "./lib/stack";
 


### PR DESCRIPTION
Using --javascript with `algob init`, now doesn't throws any error.
Task: https://www.pivotaltracker.com/story/show/183626726