### PR TITLE
remove the checks and the constants for app/asset limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Features, Bug Fixes, API Breaking, Deprecated, Infrastructure, Template Updates
 
 ### Features
 
+- Remove limits from `Runtime` for amount of apps/assets one account can create/opt-in to.
+
 #### TEALv8
 
 - Support for `switch` opcode.

--- a/packages/runtime/src/account.ts
+++ b/packages/runtime/src/account.ts
@@ -8,9 +8,6 @@ import {
 	ALGORAND_ACCOUNT_MIN_BALANCE,
 	APPLICATION_BASE_FEE,
 	ASSET_CREATION_FEE,
-	MAX_ALGORAND_ACCOUNT_ASSETS,
-	MAX_ALGORAND_ACCOUNT_CREATED_APPS,
-	MAX_ALGORAND_ACCOUNT_OPTEDIN_APPS,
 	SSC_VALUE_BYTES,
 	SSC_VALUE_UINT,
 } from "./lib/constants";
@@ -241,14 +238,6 @@ export class AccountStore implements AccountStoreI {
 	 * @param asaDef Asset Definitions
 	 */
 	addAsset(assetId: number, name: string, asaDef: types.ASADef): modelsv2.AssetParams {
-		if (this.createdAssets.size === MAX_ALGORAND_ACCOUNT_ASSETS) {
-			throw new RuntimeError(RUNTIME_ERRORS.ASA.MAX_LIMIT_ASSETS, {
-				name: name,
-				address: this.address,
-				max: MAX_ALGORAND_ACCOUNT_ASSETS,
-			});
-		}
-
 		this.minBalance += ASSET_CREATION_FEE;
 		const asset = new Asset(assetId, asaDef, this.address, name);
 		this.createdAssets.set(asset.id, asset.definitions);
@@ -331,19 +320,11 @@ export class AccountStore implements AccountStoreI {
 
 	/**
 	 * Deploy application in account's state
-	 * check maximum account creation limit
 	 * @param appID application index
 	 * @param appDefinition application definition metadata
 	 * NOTE - approval and clear program must be the TEAL code as string
 	 */
 	addApp(appID: number, appDefinition: types.AppDefinitionFromSource): CreatedAppM {
-		if (this.createdApps.size === MAX_ALGORAND_ACCOUNT_CREATED_APPS) {
-			throw new RuntimeError(RUNTIME_ERRORS.GENERAL.MAX_LIMIT_APPS, {
-				address: this.address,
-				max: MAX_ALGORAND_ACCOUNT_CREATED_APPS,
-			});
-		}
-
 		// raise minimum balance
 		// https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract
 		this.minBalance +=
@@ -361,12 +342,6 @@ export class AccountStore implements AccountStoreI {
 		if (localState) {
 			throw new Error(`${this.address} is already opted in to app ${appID}`);
 		} else {
-			if (this.appsLocalState.size === MAX_ALGORAND_ACCOUNT_OPTEDIN_APPS) {
-				throw new Error(
-					`Maximum Opt In applications per account is ${MAX_ALGORAND_ACCOUNT_OPTEDIN_APPS}`
-				);
-			}
-
 			// https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract
 			this.minBalance +=
 				APPLICATION_BASE_FEE +
@@ -389,13 +364,6 @@ export class AccountStore implements AccountStoreI {
 		if (accAssetHolding) {
 			console.warn(`${this.address} is already opted in to asset ${assetIndex}`);
 		} else {
-			if (this.createdAssets.size + this.assets.size === MAX_ALGORAND_ACCOUNT_ASSETS) {
-				throw new RuntimeError(RUNTIME_ERRORS.ASA.MAX_LIMIT_ASSETS, {
-					address: assetHolding.creator,
-					max: MAX_ALGORAND_ACCOUNT_ASSETS,
-				});
-			}
-
 			this.minBalance += ASSET_CREATION_FEE;
 			this.assets.set(assetIndex, assetHolding);
 		}

--- a/packages/runtime/src/errors/errors-list.ts
+++ b/packages/runtime/src/errors/errors-list.ts
@@ -515,13 +515,6 @@ const runtimeGeneralErrors = {
 		title: "Round Error",
 		description: `Round Error`,
 	},
-	MAX_LIMIT_APPS: {
-		number: 1303,
-		message:
-			"Error while creating app for %address%. Maximum created apps for an account is %max%",
-		title: "App Creation Error",
-		description: `App Creation Error`,
-	},
 	INVALID_SECRET_KEY: {
 		number: 1304,
 		message: "invalid secret key: %secretkey%",
@@ -754,13 +747,6 @@ const runtimeAsaErrors = {
 		message: `Asset with Index %assetId% not found`,
 		title: "Asset Not Found",
 		description: "Asset Not Found",
-	},
-	MAX_LIMIT_ASSETS: {
-		number: 1503,
-		message:
-			"Error while creating asset %name% for %address%. Maximum created assets for an account is %max%",
-		title: "Asset Creation Error",
-		description: `Asset Creation Error`,
 	},
 	MANAGER_ERROR: {
 		number: 1504,

--- a/packages/runtime/src/lib/constants.ts
+++ b/packages/runtime/src/lib/constants.ts
@@ -44,11 +44,6 @@ export const publicKeyLength = 32;
 export const proofLength = 80;
 export const seedLength = 32;
 
-export const MAX_ALGORAND_ACCOUNT_ASSETS = 1000;
-export const MAX_ALGORAND_ACCOUNT_CREATED_APPS = 10;
-
-export const MAX_ALGORAND_ACCOUNT_OPTEDIN_APPS = 50;
-
 //smart contract constraints
 // https://developer.algorand.org/docs/get-details/parameter_tables/
 export const MAX_GLOBAL_SCHEMA_ENTRIES = 64;

--- a/packages/runtime/test/src/runtime.ts
+++ b/packages/runtime/test/src/runtime.ts
@@ -1466,3 +1466,35 @@ describe("Funtions related to runtime chain", function () {
 		assert.equal(currentBlock.timestamp + BlockFinalisationTime, newBlock.timestamp);
 	});
 });
+describe.only("Application/assets limits for one account", function () {
+	// Before there were limits for how many apps/assets one account is allowed to deploy/opt-in to.
+	// The limits were removed and this is what we test here.
+	useFixture(basicFixture);
+	let runtime: Runtime;
+	const approvalClearProgramFilename = "clear.teal";
+	const appDefinition: types.AppDefinitionFromFile = {
+			appName: "app",
+			metaType: types.MetaType.FILE,
+			approvalProgramFilename: approvalClearProgramFilename,
+			clearProgramFilename: approvalClearProgramFilename,
+			globalBytes: 0,
+			globalInts: 0,
+			localBytes: 0,
+			localInts: 0,
+		};
+	let alice : AccountStore;
+	const appsToBeDeployed = [...Array(20).keys()];
+
+    before(function () {
+		runtime = new Runtime([]);
+		[alice] = runtime.defaultAccounts();
+		
+	});
+
+	appsToBeDeployed.forEach(function(appIndex) {
+		it(`Should deploy ${appIndex} app`, function () {
+			appDefinition.appName = "app".concat(appIndex.toString());
+			assert.doesNotThrow(() => runtime.deployApp(alice.account, appDefinition, {}));
+		});
+	})
+});

--- a/packages/runtime/test/src/runtime.ts
+++ b/packages/runtime/test/src/runtime.ts
@@ -1466,7 +1466,7 @@ describe("Funtions related to runtime chain", function () {
 		assert.equal(currentBlock.timestamp + BlockFinalisationTime, newBlock.timestamp);
 	});
 });
-describe.only("Application/assets limits for one account", function () {
+describe("Application/assets limits for one account", function () {
 	// Before there were limits for how many apps/assets one account is allowed to deploy/opt-in to.
 	// The limits were removed and this is what we test here.
 	useFixture(basicFixture);


### PR DESCRIPTION
Closes #x

## Proposed Changes

- Remove limit on how many apps/asset address can create/be opted-in
- [info](https://developer.algorand.org/articles/algorand-unlimited-assets-and-smart-contracts/)

## TODO

- [x] update change log

## Potential followups

I do not think there is need for test. We can't overflow it and the exceptions were removed 
