### PR TITLE
Update `appendSignMultisigTransaction` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Features, Bug Fixes, API Breaking, Deprecated, Infrastructure, Template Updates
 ### Breaking Changes
 
 - The method `ProduceBlock` has been renamed to `ProduceBlocks(numberOfBlocks=1)` and now accepts optional parameter that allows user to specify the number of blocks that will be produced.
+- `appendSignMultisigTransaction` now expects `Encoded MultiSignature Transaction` as first argument and returns an object containing a blob key encoded in base64.
 
 #### TEALv8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Features, Bug Fixes, API Breaking, Deprecated, Infrastructure, Template Updates
 ### Breaking Changes
 
 - The method `ProduceBlock` has been renamed to `ProduceBlocks(numberOfBlocks=1)` and now accepts optional parameter that allows user to specify the number of blocks that will be produced.
-- `appendSignMultisigTransaction` now expects `Encoded MultiSignature Transaction` as first argument and returns an object containing a blob key encoded in base64.
+- `appendSignMultisigTransaction` now expects `EncodedSignedTransaction` as first argument and returns an object containing a blob key encoded in base64.
 
 #### TEALv8
 

--- a/packages/web/src/lib/web-mode.ts
+++ b/packages/web/src/lib/web-mode.ts
@@ -195,7 +195,7 @@ export class WebMode {
 	): Promise<JsonPayload> {
 		try {
 			if (!txn.msig) {
-				throw new Error("Current transaction is not a Multisign Transaction.")
+				throw new Error("Current transaction is not a Multisig Transaction.")
 			}
 			const encodedTxn = this.algoSigner.encoding.msgpackToBase64(encodeObj(txn.txn))
 			const mparams = txn.msig as algosdk.EncodedMultisig;

--- a/packages/web/src/lib/web-mode.ts
+++ b/packages/web/src/lib/web-mode.ts
@@ -194,6 +194,9 @@ export class WebMode {
 		signers?: string[]
 	): Promise<JsonPayload> {
 		try {
+			if (!txn.msig) {
+				throw new Error("Current transaction is not a Multisign Transaction.")
+			}
 			const encodedTxn = this.algoSigner.encoding.msgpackToBase64(encodeObj(txn.txn))
 			const mparams = txn.msig as algosdk.EncodedMultisig;
 			const version = mparams.v;


### PR DESCRIPTION
`appendSignMultisigTransaction` now expects `Encoded MultiSignature Transaction` as first argument and returns an object containing a blob key encoded in base64.