### PR TITLE
Update `connectToMyAlgo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,19 @@ Features, Bug Fixes, API Breaking, Deprecated, Infrastructure, Template Updates
 - Fixed `pre-commit` scirpt that did not work properly and skiped the `lint-staged` part.
 
 ### Features
+
 - Allow user to query foreign applications accounts using the `appID` field.
 
 - Remove limits from `Runtime` for amount of apps/assets one account can create/opt-in to.
 - Add `getGenesisHashFromName(name: string)` utility function to `@algo-builder/web`.
 - Add `mainnetGenesisHash`, `testnetGenesisHash`, `betanetGenesisHash`, `runtimeGenesisHash` constants.
-- Add `parseABIContractFile(pathToFilePath)` method to `Runtime` and `Deployer`. If the currently used network is defined in the ABI file additonal field `appID`  will be added to a contract.
+- Add `parseABIContractFile(pathToFilePath)` method to `Runtime` and `Deployer`. If the currently used network is defined in the ABI file additonal field `appID` will be added to a contract.
+- Added `allowMultipleAccounts` parameter to `connectToMyAlgo` method of `WebMode` to give user the flexibility to allow multi accounts login using MyAlgo Wallet.
 
 ### Breaking Changes
 
-- The method `ProduceBlock` has been  renamed to `ProduceBlocks(numberOfBlocks=1)` and now accepts optional parameter that allows user to specify the number of blocks that will be produced.
+- The method `ProduceBlock` has been renamed to `ProduceBlocks(numberOfBlocks=1)` and now accepts optional parameter that allows user to specify the number of blocks that will be produced.
+
 #### TEALv8
 
 - Support for `switch` opcode.

--- a/packages/web/src/lib/myalgowallet-mode.ts
+++ b/packages/web/src/lib/myalgowallet-mode.ts
@@ -89,12 +89,12 @@ export class MyAlgoWalletSession {
 		}
 	}
 
-	// https://connect.myalgo.com/docs/interactive-examples/Connect
 	/**
 	 * @async
 	 * @description Connects to the MyAlgo Wallet by opening up its dialog box to login
 	 * @param allowMultipleAccounts allow selection of multiple accounts from MyAlgo Wallet, default is true
 	 * For Multisig you need to allow multiple accounts login
+	 * for more info visit: https://connect.myalgo.com/docs/interactive-examples/Connect
 	 */
 	async connectToMyAlgo(allowMultipleAccounts = true): Promise<void> {
 		try {

--- a/packages/web/src/lib/myalgowallet-mode.ts
+++ b/packages/web/src/lib/myalgowallet-mode.ts
@@ -90,10 +90,16 @@ export class MyAlgoWalletSession {
 	}
 
 	// https://connect.myalgo.com/docs/interactive-examples/Connect
-	async connectToMyAlgo(): Promise<void> {
+	/**
+	 * @async
+	 * @description Connects to the MyAlgo Wallet by opening up its dialog box to login
+	 * @param allowMultipleAccounts allow selection of multiple accounts from MyAlgo Wallet, default is true
+	 * For Multisig you need to allow multiple accounts login
+	 */
+	async connectToMyAlgo(allowMultipleAccounts = true): Promise<void> {
 		try {
 			this.accounts = await this.connector.connect({
-				shouldSelectOneAccount: false, // for multisig we need to allow multiple accounts login
+				shouldSelectOneAccount: !allowMultipleAccounts,
 				openManager: true,
 			});
 			this.addresses = this.accounts.map((account) => account.address);


### PR DESCRIPTION
`allowMultipleAccounts` parameter added to `connectToMyAlgo` to give user the flexibility to allow multi accounts login using MyAlgo Wallet 