### PR TITLE
Rename sign msig transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Features, Bug Fixes, API Breaking, Deprecated, Infrastructure, Template Updates
 ### Breaking Changes
 
 - The method `ProduceBlock` has been renamed to `ProduceBlocks(numberOfBlocks=1)` and now accepts optional parameter that allows user to specify the number of blocks that will be produced.
-- `appendSignMultisigTransaction` is renamed to `signMsigTransaction` and expects `EncodedSignedTransaction` as first argument and returns an object containing a blob key encoded in base64.
+- `appendSignMultisigTransaction` is renamed to `signMsigTx` which expects `EncodedSignedTransaction` as first argument and returns an object containing a blob key encoded in base64.
 
 #### TEALv8
 
@@ -88,7 +88,7 @@ Features, Bug Fixes, API Breaking, Deprecated, Infrastructure, Template Updates
 - Added support for `secp256r1` curve to `ecdsa_verify` and `ecdsa_pk_decompress` opcodes.
 - Added support for `FirstValidTime` field for transactions opcode.
 - Added program length check on app update on the basis of extra pages in `runtime`.
-- Added support for  `Runtime` to add account from `config` file.
+- Added support for `Runtime` to add account from `config` file.
 
 #### @algo-builder/web
 

--- a/packages/web/src/lib/web-mode.ts
+++ b/packages/web/src/lib/web-mode.ts
@@ -185,24 +185,21 @@ export class WebMode {
 
 	/**
 	 * Appends signature to a multisig transaction using algosigner
-	 * @param txn Multisignature Encoded Transaction  
+	 * @param txn Multisignature Encoded Transaction
 	 * @param signers a subset of addresses to sign the transaction
 	 * return an object containing a blob key encoded in base64
 	 */
-	async signMsigTransaction(
-		txn: EncodedSignedTransaction,
-		signers?: string[]
-	): Promise<JsonPayload> {
+	async signMsigTx(txn: EncodedSignedTransaction, signers?: string[]): Promise<JsonPayload> {
 		try {
 			if (!txn.msig) {
-				throw new Error("Current transaction is not a Multisig Transaction.")
+				throw new Error("Current transaction is not a Multisig Transaction.");
 			}
-			const encodedTxn = this.algoSigner.encoding.msgpackToBase64(encodeObj(txn.txn))
+			const encodedTxn = this.algoSigner.encoding.msgpackToBase64(encodeObj(txn.txn));
 			const mparams = txn.msig as algosdk.EncodedMultisig;
 			const version = mparams.v;
 			const threshold = mparams.thr;
 			const addr = mparams.subsig.map((signData) => {
-				return algosdk.encodeAddress(signData.pk)
+				return algosdk.encodeAddress(signData.pk);
 			});
 
 			const multisigParams = {
@@ -220,11 +217,11 @@ export class WebMode {
 			]);
 
 			const signedTxnJson = signedTxn[0] as JsonPayload;
-			let combineBlob = this.algoSigner.encoding.base64ToMsgpack(signedTxnJson.blob as string)
+			let combineBlob = this.algoSigner.encoding.base64ToMsgpack(signedTxnJson.blob as string);
 			// multiple signatures
 			if (txn.msig?.subsig.findIndex((item) => item.s?.length) !== -1) {
 				const blob1 = encodeObj(txn);
-				const blob2 = combineBlob
+				const blob2 = combineBlob;
 				combineBlob = algosdk.mergeMultisigTransactions([blob1, blob2]);
 			}
 			const outputBase64 = this.algoSigner.encoding.msgpackToBase64(combineBlob);


### PR DESCRIPTION
Closes #x

## Proposed Changes

renamed `web.signMsigTransaction` to `web.signMsigTx` to make it "compatible" with other functions.
