### PR TITLE
Windows compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Features, Bug Fixes, API Breaking, Deprecated, Infrastructure, /example Updates
 ### Bug Fixes
 
 - Fixed `pre-commit` script that did not work properly and skipped the `lint-staged` part.
+- Fixed compiling contracts on Windows.
 
 ### Features
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -45,11 +45,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
-                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2022.9.24"
+            "index": "pypi",
+            "version": "==2022.12.7"
         },
         "cffi": {
             "hashes": [
@@ -125,7 +125,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.1.1"
         },
         "cleo": {
@@ -133,7 +133,7 @@
                 "sha256:097c9d0e0332fd53cc89fc11eb0a6ba0309e6a3933c08f7b38558555486925d3",
                 "sha256:ff53056589300976e960f75afb792dfbfc9c78dcbb5a448e207a17b643826360"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "markers": "python_version >= '3.7' and python_version < '4'",
             "version": "==1.0.0a5"
         },
         "colorama": {
@@ -149,7 +149,7 @@
                 "sha256:300f4b0825f57688b47b6d70c6a31de33512eb2fa1ac614f780939aa0cf91680",
                 "sha256:42ca7b6ce88b6c7433e2ce47ea884e91ec93104a4b754998be498a8e6c3d37dd"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==0.3.1"
         },
         "cryptography": {
@@ -196,7 +196,7 @@
                 "sha256:14ac6ec1f1ba6905c4d8cb90fd0bc55394f5678183752c90e44812bf28d7a515",
                 "sha256:2c77522e31b7c88b1ab457a1f3c9ae38947ad719732260ba77ee8a3deb58622a"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==0.14.1"
         },
         "dulwich": {
@@ -445,11 +445,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+                "sha256:2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3",
+                "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==21.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==22.0"
         },
         "pexpect": {
             "hashes": [
@@ -495,7 +495,7 @@
                 "sha256:0ab006a40cb38d6a38b97264f6835da2f08a96912f2728ce668e9ac6a34f686f",
                 "sha256:ea0f5a90b339cde132b4e43cff78a1b440cd928db864bb67cfc97fdfcefe7218"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "markers": "python_version >= '3.7' and python_version < '4'",
             "version": "==1.3.2"
         },
         "poetry-plugin-export": {
@@ -503,7 +503,7 @@
                 "sha256:109fb43ebfd0e79d8be2e7f9d43ba2ae357c4975a18dfc0cfdd9597dd086790e",
                 "sha256:9a1dd42765408931d7831738749022651d43a2968b67c988db1b7a567dfe41ef"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "markers": "python_version >= '3.7' and python_version < '4'",
             "version": "==1.2.0"
         },
         "prettytable": {
@@ -640,14 +640,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==1.5.0"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
-            ],
-            "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.0.9"
         },
         "pyrsistent": {
             "hashes": [
@@ -817,7 +809,7 @@
         "tealer": {
             "editable": true,
             "git": "https://github.com/crytic/tealer.git",
-            "ref": "1e68d1ed61e18780ac7eebc1828cf30deba0c932"
+            "ref": "1dae24d8cc84d98f87b90a949329bbb830eb5da2"
         },
         "tomli": {
             "hashes": [

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.6)
+    activesupport (6.0.6.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -16,7 +16,7 @@ GEM
     colorator (1.1.0)
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.2.0)
     dnsruby (1.61.5)
       simpleidn (~> 0.1)
     em-websocket (0.5.2)
@@ -211,9 +211,9 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.14.4)
+    minitest (5.17.0)
     multipart-post (2.1.1)
-    nokogiri (1.13.9-x86_64-linux)
+    nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     octokit (4.20.0)
       faraday (>= 0.9)
@@ -221,7 +221,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
-    racc (1.6.0)
+    racc (1.6.1)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -253,7 +253,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    zeitwerk (2.4.2)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   x86_64-linux

--- a/packages/algob/src/lib/compile.ts
+++ b/packages/algob/src/lib/compile.ts
@@ -9,6 +9,7 @@ import YAML from "yaml";
 import { assertDir, ASSETS_DIR, CACHE_DIR } from "../internal/core/project-structure";
 import { timestampNow } from "../lib/time";
 import type { ASCCache, SCParams } from "../types";
+import { NO_FILE_OR_DIRECTORY_ERROR } from "./constants";
 
 export const tealExt = ".teal";
 export const pyExt = ".py";
@@ -111,7 +112,7 @@ export class CompileOp {
 			const p = path.join(CACHE_DIR, filename + ".yaml");
 			return YAML.parse(await fs.promises.readFile(p, "utf8")) as ASCCache;
 		} catch (e) {
-			if (types.isFileError(e) && e?.errno === -2) {
+			if ((e as NodeJS.ErrnoException)?.code === NO_FILE_OR_DIRECTORY_ERROR) {
 				return undefined;
 			} // handling a not existing file
 			throw e;

--- a/packages/algob/src/lib/constants.ts
+++ b/packages/algob/src/lib/constants.ts
@@ -5,3 +5,4 @@ export const MIN_UINT64 = 0n;
 export const MAX_UINT64 = 0xffffffffffffffffn;
 // mock algod credentials
 export const mockAlgod = new Algodv2("dummyToken", "https://dummyNetwork", 8080);
+export const NO_FILE_OR_DIRECTORY_ERROR = "ENOENT"

--- a/packages/algob/src/lib/files.ts
+++ b/packages/algob/src/lib/files.ts
@@ -1,9 +1,10 @@
 import { getPathFromDirRecursive } from "@algo-builder/runtime";
-import { BuilderError, ERRORS, types } from "@algo-builder/web";
+import { BuilderError, ERRORS } from "@algo-builder/web";
 import fs from "fs-extra";
 import path from "path";
 
 import { ASSETS_DIR } from "../internal/core/project-structure";
+import { NO_FILE_OR_DIRECTORY_ERROR } from "./constants";
 
 function normalizePaths(mainPath: string, paths: string[]): string[] {
 	return paths.map((n) => path.relative(mainPath, n));
@@ -45,7 +46,7 @@ export function loadEncodedTxFromFile(fileName: string): Uint8Array | undefined 
 		const buffer = fs.readFileSync(p);
 		return Uint8Array.from(buffer);
 	} catch (e) {
-		if (types.isFileError(e) && e?.errno === -2) {
+		if ((e as NodeJS.ErrnoException)?.code === NO_FILE_OR_DIRECTORY_ERROR) {
 			return undefined;
 		} // handling a not existing file
 		throw e;

--- a/packages/algob/src/lib/msig.ts
+++ b/packages/algob/src/lib/msig.ts
@@ -1,5 +1,4 @@
 import { getPathFromDirRecursive } from "@algo-builder/runtime";
-import { types } from "@algo-builder/web";
 import {
 	Account,
 	appendSignMultisigTransaction,
@@ -17,6 +16,7 @@ import fs from "fs";
 
 import { ASSETS_DIR } from "../internal/core/project-structure";
 import { LogicSig } from "../types";
+import { NO_FILE_OR_DIRECTORY_ERROR } from "./constants";
 import { isSignedTx } from "./tx";
 
 export const blsigExt = ".blsig";
@@ -56,7 +56,7 @@ export async function readMsigFromFile(filename: string): Promise<EncodedMultisi
 		const msig = fs.readFileSync(p, "utf8").split("LogicSig: ")[1];
 		return await decodeMsigObj(msig);
 	} catch (e) {
-		if (types.isFileError(e) && e?.errno === -2) {
+		if ((e as NodeJS.ErrnoException)?.code === NO_FILE_OR_DIRECTORY_ERROR) {
 			return undefined;
 		} // handling a not existing file
 		throw e;
@@ -77,7 +77,7 @@ export async function readBinaryMultiSig(filename: string): Promise<string | und
 		const p = getPathFromDirRecursive(ASSETS_DIR, filename) as string;
 		return fs.readFileSync(p, "base64");
 	} catch (e) {
-		if (types.isFileError(e) && e?.errno === -2) {
+		if ((e as NodeJS.ErrnoException)?.code === NO_FILE_OR_DIRECTORY_ERROR) {
 			return undefined;
 		} // handling a not existing file
 		throw e;

--- a/packages/runtime/src/lib/constants.ts
+++ b/packages/runtime/src/lib/constants.ts
@@ -891,3 +891,8 @@ export const NETWORK_DEFAULT = "default";
 
 export const PythonCommands = ['python3', 'python', 'py'] as const;
 export type PythonCommand = typeof PythonCommands[number];
+
+export enum searchStrCommand {
+	Windows = "Findstr",
+	UnixLinux = "grep",
+}

--- a/packages/runtime/src/lib/constants.ts
+++ b/packages/runtime/src/lib/constants.ts
@@ -888,3 +888,6 @@ export enum NumIndex {
 export const JS_CONFIG_FILENAME = "algob.config.js";
 export const TS_CONFIG_FILENAME = "algob.config.ts";
 export const NETWORK_DEFAULT = "default";
+
+export const PythonCommands = ['python3', 'python', 'py'] as const;
+export type PythonCommand = typeof PythonCommands[number];

--- a/packages/runtime/src/lib/pycompile-op.ts
+++ b/packages/runtime/src/lib/pycompile-op.ts
@@ -84,7 +84,7 @@ export class PyCompileOp {
 	private getPythonCommand(): PythonCommand {
 		const pyCommand = PythonCommands.find((command: PythonCommand) => {
 			try {
-				execSync(command + " -v", { stdio: "pipe" });
+				execSync(command + " -V", { stdio: "pipe" });
 			} catch {
 				return false;
 			}

--- a/packages/runtime/src/lib/pycompile-op.ts
+++ b/packages/runtime/src/lib/pycompile-op.ts
@@ -3,8 +3,9 @@ import { exec, execSync, spawnSync, SpawnSyncReturns } from "child_process";
 import YAML from "yaml";
 
 import type { ReplaceParams, SCParams } from "../types";
-import { PythonCommand, PythonCommands } from "./constants";
+import { PythonCommand, PythonCommands, searchStrCommand } from "./constants";
 import { getPathFromDirRecursive } from "./files";
+import Os from "os";
 
 export const tealExt = ".teal";
 export const pyExt = ".py";
@@ -33,6 +34,20 @@ export class PyCompileOp {
 		}
 
 		return content;
+	}
+
+	/**
+	 * Description: Check if current OS is Windows
+	 */
+	private isWindows(): boolean {
+		return Os.platform() === "win32";
+	}
+
+	/**
+	 * Description: Returns the command to search strings according to OS
+	 */
+	private getSearchStrCommand(): searchStrCommand {
+		return this.isWindows() ? searchStrCommand.Windows : searchStrCommand.UnixLinux;
 	}
 
 	/**
@@ -90,10 +105,10 @@ export class PyCompileOp {
 			}
 			return command;
 		});
-		if (!pyCommand){
-			throw new Error(`executable python command not found.`)
+		if (!pyCommand) {
+			throw new Error(`executable python command not found.`);
 		}
-		return pyCommand
+		return pyCommand;
 	}
 
 	/**
@@ -117,7 +132,8 @@ export class PyCompileOp {
 	 * @param module: Module to be checked if installed or not.
 	 */
 	private validatePythonModule(module: string) {
-		exec(`pip list | grep ${module}`, (err: any) => {
+		const searchStrCommand = this.getSearchStrCommand();
+		exec(`pip list | ${searchStrCommand} ${module}`, (err: any) => {
 			if (err) {
 				throw new Error(
 					`"${module}" module not found. Please try running "pip install ${module}"`

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -334,15 +334,6 @@ export interface RequestError extends Error {
 	error?: Error;
 }
 
-export interface FileError extends Error {
-	errno: number;
-}
-
-// This function is used to check if given objects implements `FileError` interface
-export function isFileError(object: unknown): object is FileError {
-	return Object.prototype.hasOwnProperty.call(object, "errno");
-}
-
 // This function is used to check if given objects implements `RequestError` interface
 // https://www.technicalfeeder.com/2021/02/how-to-check-if-a-object-implements-an-interface-in-typescript/
 export function isRequestError(object: unknown): object is RequestError {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4291,13 +4291,13 @@ __metadata:
   linkType: hard
 
 "json5@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "json5@npm:1.0.1"
+  version: 1.0.2
+  resolution: "json5@npm:1.0.2"
   dependencies:
     minimist: ^1.2.0
   bin:
     json5: lib/cli.js
-  checksum: e76ea23dbb8fc1348c143da628134a98adf4c5a4e8ea2adaa74a80c455fc2cdf0e2e13e6398ef819bfe92306b610ebb2002668ed9fc1af386d593691ef346fc3
+  checksum: 866458a8c58a95a49bef3adba929c625e82532bcff1fe93f01d29cb02cac7c3fe1f4b79951b7792c2da9de0b32871a8401a6e3c5b36778ad852bf5b8a61165d7
   languageName: node
   linkType: hard
 
@@ -5532,15 +5532,6 @@ __metadata:
   bin:
     qrcode: ./bin/qrcode
   checksum: 8c1a7ee3092c0ed60f0413594af879ac6dffb897d4921144a8e7ae3dce40c04ba6457ab21664ca43934ba3fe19cced85abaf0b87b07916239d7254d4bb4fcf13
-  languageName: node
-  linkType: hard
-
-"qs@npm:^6.9.4":
-  version: 6.11.0
-  resolution: "qs@npm:6.11.0"
-  dependencies:
-    side-channel: ^1.0.4
-  checksum: 6e1f29dd5385f7488ec74ac7b6c92f4d09a90408882d0c208414a34dd33badc1a621019d4c799a3df15ab9b1d0292f97c1dd71dc7c045e69f81a8064e5af7297
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #689

## Proposed Changes

-Add compatibility to compile contracts on Windows OS.

## TODO

- [x] Add support to run `python3`, `python` or `py` command, depending on which is available.
- [x] Refactor handling of not existing files to be OS agnostic, using `error.code` attribute instead `error.errno`.
- [x] Use `Findstr` command intead of `grep` if current OS is Windows.
- [x] Update change log

## Potential followups

Currently, some unit tests assertions are not working on Windows because of the OS character difference (backslashes vs forward slashes, LF vs CR-LF). e.g.

![image](https://user-images.githubusercontent.com/32117492/215382211-f7f76f31-114b-48d5-9f22-ccca2c4f1080.png)

![image](https://user-images.githubusercontent.com/32117492/215382001-eb2bf417-36b6-492e-b084-d4902937caf3.png)

I suggest implementing unit test support on Windows if the Windows developer community justifies it.